### PR TITLE
Added Ticket Stream for Intercom

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
@@ -24,6 +24,9 @@ from airbyte_cdk.sources.streams.core import Stream
 
 RequestInput = Union[str, Mapping[str, str]]
 
+HEADER_OVERRIDES = {
+    "Intercom-Version": "2.10"
+}
 
 @dataclass
 class IncrementalSingleSliceCursor(Cursor):
@@ -371,7 +374,10 @@ class HttpRequesterWithRateLimiter(HttpRequester):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        return self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
+        headers = self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
+        for key in HEADER_OVERRIDES:
+            headers[key] = HEADER_OVERRIDES[key]
+        return headers
 
     def get_request_body_json(
         self,

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
@@ -375,6 +375,8 @@ class HttpRequesterWithRateLimiter(HttpRequester):
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
         headers = self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
+        # This was needed due to an Airbyte issue where the api version 2.10 was getting truncated to 2.1 when parsed
+        # from the YAML file. The overrides can be removed once that issue is resolved.
         for key in HEADER_OVERRIDES:
             headers[key] = HEADER_OVERRIDES[key]
         return headers

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -357,6 +357,13 @@ definitions:
       path: "conversations/search"
       data_field: "conversations"
       page_size: 150
+  tickets: # Will be unsupported until Intercom API v2.10 is fully supported in Airbyte
+    $ref: "#/definitions/stream_incremental_search"
+    $parameters:
+      name: "tickets"
+      path: "tickets/search"
+      data_field: "tickets"
+      page_size: 150
 
 streams:
   - "#/definitions/admins"
@@ -373,6 +380,7 @@ streams:
   - "#/definitions/conversation_parts"
   - "#/definitions/conversation_contacts"
   - "#/definitions/company_segments"
+  - "#/definitions/tickets"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -357,7 +357,7 @@ definitions:
       path: "conversations/search"
       data_field: "conversations"
       page_size: 150
-  tickets: # Will be unsupported until Intercom API v2.10 is fully supported in Airbyte
+  tickets:
     $ref: "#/definitions/stream_incremental_search"
     $parameters:
       name: "tickets"

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -20,7 +20,7 @@ definitions:
       type: BearerAuthenticator
       api_token: "{{ config['access_token'] }}"
     request_headers:
-      Intercom-Version: "2.5" # ATTENTION: API version change is possible here
+      Intercom-Version: "2.10" # ATTENTION: API version change is possible here
       Accept: "application/json"
     error_handler:
       type: "DefaultErrorHandler"

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/tickets.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/tickets.json
@@ -1,0 +1,56 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": ["null", "string"]
+    },
+    "id": {
+      "type": ["null", "string"]
+    },
+    "ticket_id": {
+      "type": ["null", "string"]
+    },
+    "category": {
+      "type": ["null", "string"]
+    },
+    "ticket_attributes": {
+      "type": ["null", "object"]
+    },
+    "ticket_state": {
+      "type": ["null", "string"]
+    },
+    "ticket_type": {
+      "type": ["null", "object"]
+    },
+    "contacts": {
+      "type": ["null", "object"]
+    },
+    "admin_assignee_id": {
+      "type": ["null", "string"]
+    },
+    "team_assignee_id": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "integer"]
+    },
+    "updated_at": {
+      "type": ["null", "integer"]
+    },
+    "open": {
+      "type": ["null", "boolean"]
+    },
+    "snoozed_until": {
+      "type": ["null", "integer"]
+    },
+    "linked_objects": {
+      "type": ["null", "object"]
+    },
+    "ticket_parts": {
+      "type": ["null", "object"]
+    },
+    "is_shared": {
+      "type": ["null", "boolean"]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/tickets.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/tickets.json
@@ -14,16 +14,112 @@
       "type": ["null", "string"]
     },
     "ticket_attributes": {
-      "type": ["null", "object"]
+      "type": ["null", "object"],
+      "properties": {
+        "name": {
+          "type": ["null", "string"]
+        },
+        "question": {
+          "type": ["null", "string"]
+        },
+        "Title": {
+          "type": ["null", "string"]
+        }
+      }
     },
     "ticket_state": {
       "type": ["null", "string"]
     },
     "ticket_type": {
-      "type": ["null", "object"]
+      "type": ["null", "object"],
+      "additional_properties": true,
+      "properties": {
+        "id": {
+          "type": ["null", "string"]
+        },
+        "type": {
+          "type": ["null", "string"]
+        },
+        "category": {
+          "type": ["null", "string"]
+        },
+        "name": {
+          "type": ["null", "string"]
+        },
+        "description": {
+          "type": ["null", "string"]
+        },
+        "icon": {
+          "type": ["null", "string"]
+        },
+        "workspace_id": {
+          "type": ["null", "string"]
+        },
+        "archived": {
+          "type": ["null", "boolean"]
+        },
+        "created_at": {
+          "type": ["null", "integer"]
+        },
+        "updated_at": {
+          "type": ["null", "integer"]
+        },
+        "is_internal": {
+          "type": ["null", "boolean"]
+        },
+        "ticket_type_attributes": {
+          "type": ["null", "object"],
+          "properties": {
+            "type": {
+              "type": ["null", "string"]
+            },
+            "ticket_type_attributes": {
+              "type": ["null", "array"],
+              "items": {
+                "type": ["object", "null"],
+                "properties": {
+                  "type": { "type": ["string", "null"] },
+                  "id": { "type": ["string", "null"] },
+                  "workspace_id": { "type": ["string", "null"] },
+                  "name": { "type": ["string", "null"] },
+                  "description": { "type": ["string", "null"] },
+                  "data_type": { "type": ["string", "null"] },
+                  "input_options": { "type": ["string", "null"] },
+                  "order": { "type": ["integer", "null"] },
+                  "required_to_create": { "type": ["boolean", "null"] },
+                  "required_to_create_for_contacts": { "type": ["boolean", "null"] },
+                  "visible_on_create": { "type": ["boolean", "null"] },
+                  "visible_to_contacts": { "type": ["boolean", "null"] },
+                  "default": { "type": ["boolean", "null"] },
+                  "ticket_type_id": { "type": ["integer", "null"] },
+                  "archived": { "type": ["boolean", "null"] },
+                  "created_at": { "type": ["integer", "null"] },
+                  "updated_at": { "type": ["integer", "null"] }
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "contacts": {
-      "type": ["null", "object"]
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "contacts": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "properties": {
+              "type": { "type": ["string", "null"] },
+              "id": { "type": ["string", "null"] },
+              "external_id": { "type": ["string", "null"] }
+            }
+          }
+        }
+      }
     },
     "admin_assignee_id": {
       "type": ["null", "string"]
@@ -44,10 +140,89 @@
       "type": ["null", "integer"]
     },
     "linked_objects": {
-      "type": ["null", "object"]
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "total_count": {
+          "type": ["null", "number"]
+        },
+        "has_more": {
+          "type": ["null", "boolean"]
+        },
+        "data": {
+          "type": ["array", "null"],
+          "items": {
+            "type": ["object", "null"],
+            "properties": {
+              "type": { "type": ["string", "null"] },
+              "id": { "type": ["string", "null"] },
+              "category": { "type": ["string", "null"] }
+            }
+          }
+        }
+      }
     },
     "ticket_parts": {
-      "type": ["null", "object"]
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "total_count": {
+          "type": ["null", "number"]
+        },
+        "ticket_parts": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "properties": {
+              "type": { "type": ["string", "null"] },
+              "id": { "type": ["string", "null"] },
+              "body": { "type": ["string", "null"] },
+              "previous_ticket_state": { "type": ["string", "null"] },
+              "ticket_state": { "type": ["string", "null"] },
+              "created_at": { "type": ["integer", "null"] },
+              "updated_at": { "type": ["integer", "null"] },
+              "assigned_to": { 
+                "type": ["object", "null"],
+                "properties": {
+                  "type": { "type": ["string", "null"] },
+                  "id": { "type": ["string", "null"] }
+                }
+              },
+              "author": { 
+                "type": ["object", "null"],
+                "properties": {
+                  "type": { "type": ["string", "null"] },
+                  "id": { "type": ["string", "null"] },
+                  "name": { "type": ["string", "null"] },
+                  "email": { "type": ["string", "null"] }
+                }
+              },
+              "attachments": { 
+                "type": ["array", "null"],
+                "items": {
+                  "type": ["object", "null"],
+                  "properties": {
+                    "type": { "type": ["string", "null"] },
+                    "name": { "type": ["string", "null"] },
+                    "url": { "type": ["string", "null"] },
+                    "content_type": { "type": ["string", "null"] },
+                    "filesize": { "type": ["integer", "null"] },
+                    "width": { "type": ["integer", "null"] },
+                    "height": { "type": ["integer", "null"] }
+                  }
+                }
+              },
+              "external_id": { "type": ["string", "null"] },
+              "redacted": { "type": ["boolean", "null"] },
+              "part_type": { "type": ["string", "null"] }
+            }
+          }
+        }
+      }
     },
     "is_shared": {
       "type": ["null", "boolean"]


### PR DESCRIPTION
### Description:

This PR adds the Ticket stream to Intercom

<img width="919" alt="image" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/95660002/8ff536c6-dfc7-4aba-a924-55aafc137be3">

### Open Issues:

Lack of support for Intercom API v2.10 in Airbyte
<img width="1444" alt="image" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/95660002/637b5783-ecae-49d9-a3a3-52b5110f40e7">
https://github.com/airbytehq/airbyte/issues/34168

I resolved this by bumping up the version but that revealed another bug in airbyte where the version number in the YAML file is getting truncated when parsed (possibly due to float conversion). This was probably not caught because this was the first time the version id had a trailing zero.
![image](https://github.com/Encore-Post-Sales/airbyte-magnify/assets/95660002/2b051bae-c659-4aee-a936-3edf751addd3)

