### PR TITLE
[MAGPROD-3191]: Getting Intercom Connector Back to a Stable Place

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom/Dockerfile
@@ -34,5 +34,5 @@ COPY source_intercom ./source_intercom
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.3.0
 LABEL io.airbyte.name=airbyte/source-intercom


### PR DESCRIPTION
### JIRA: https://magnifyio.atlassian.net/browse/MAGPROD-3191

### Changes:
- After reverting our Airbyte code several months I found a discrepancy in the old DockerFile used to build Intercom. After updating it I was able to get Intercom to a stable point.
- This does not explain issues seen with building via the airbyte_ci but will unblock all Tesorio related work dependent on Intercom

I was able to create the connector using the updated image I built and then successfully ingest all streams in dev, including the ones that we added a few weeks ago
<img width="968" alt="image" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/95660002/5bc06b46-c387-41c9-8c6d-a40359637f98">
