### PR TITLE
add contact companies

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -298,6 +298,27 @@ definitions:
             value: "'{{ stream_slice.id }}'"
     retriever:
       $ref: "#/definitions/substream_semi_incremental/retriever"
+  contact_companies:
+    $ref: "#/definitions/substream_semi_incremental"
+    $parameters:
+      name: "contact_companies"
+      primary_key: "id"
+      path: "/contacts/{{ stream_slice.id }}/companies"
+    incremental_sync:
+      $ref: "#/definitions/substream_semi_incremental/incremental_sync"
+      # parent_complete_fetch: true
+      parent_stream_configs:
+        - type: ParentStreamConfig
+          stream: "#/definitions/contacts"
+          parent_key: "id"
+          partition_field: "id"
+    transformations:
+      - type: AddFields
+        fields:
+          - path: ["contact_id"]
+            value: "'{{ stream_slice.id }}'"
+    retriever:
+      $ref: "#/definitions/substream_semi_incremental/retriever"
 
   # incremental search
   stream_incremental_search:
@@ -347,6 +368,7 @@ streams:
   - "#/definitions/contact_attributes"
   - "#/definitions/contacts"
   - "#/definitions/contact_segments"
+  - "#/definitions/contact_companies"
   - "#/definitions/conversations"
   - "#/definitions/conversation_parts"
   - "#/definitions/conversation_contacts"

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_companies.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_companies.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null","string"]
+        },
+        "name": {
+            "type": ["null","string"]
+        },
+        "created_at": {
+            "type": ["null", "integer"]
+        },
+        "updated_at": {
+            "type": ["null", "integer"]
+        },
+        "contact_id": {
+            "type": ["null", "string"]
+        }
+    }
+}


### PR DESCRIPTION
JIRA LINK: https://magnifyio.atlassian.net/browse/MAGPROD-2776

Add contact company stream - it is a substream with the format /contacts/{contact_id}/company

and is used to ingest company objects related to a contact. We need this to unblock metadata work for Tesorio Intercom - since the company id is gong to be used to surface the universal account ids across all intercom objects. 

NOTE: Since this is an extra stream to augment joins b/w companies <-> contacts, I'll be only ingest a subset of company data from this stream. Also, complete company data is already available as part of the companies stream, so we really don't need to ingest the same data again

Screenshots show the following code works in dev and is able to ingest data to the canonical glue s3 destination.
<img width="746" alt="Screenshot 2024-01-23 at 2 28 55 PM" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/118306841/bf75eff1-27b5-42f0-ac1d-2231899700a0">
<img width="1480" alt="Screenshot 2024-01-23 at 2 29 09 PM" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/118306841/688ea289-d154-4aef-89e5-6d0b9c18d995">
