### PR TITLE
Add ticket_contacts substream

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -323,6 +323,7 @@ definitions:
     $ref: "#/definitions/substream_semi_incremental"
     incremental_sync:
       $ref: "#/definitions/substream_semi_incremental/incremental_sync"
+      cursor_field: ""
       parent_stream_configs:
         - type: ParentStreamConfig
           stream: "#/definitions/tickets"
@@ -338,9 +339,11 @@ definitions:
           - path: ["ticket_id"]
             value: "'{{ stream_slice.id }}'"
     retriever:
-      $ref: "#/definitions/substream_semi_incremental/retriever"
+      $ref: "#/definitions/stream_full_refresh/retriever"
+      paginator:
+        type: "NoPagination"
       record_selector:
-        $ref: "#/definitions/substream_semi_incremental/retriever/record_selector"
+        $ref: "#/definitions/selector"
         extractor:
           field_path: ["contacts", "contacts"]
 

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -319,6 +319,30 @@ definitions:
             value: "'{{ stream_slice.id }}'"
     retriever:
       $ref: "#/definitions/substream_semi_incremental/retriever"
+  ticket_contacts:
+    $ref: "#/definitions/substream_semi_incremental"
+    incremental_sync:
+      $ref: "#/definitions/substream_semi_incremental/incremental_sync"
+      parent_stream_configs:
+        - type: ParentStreamConfig
+          stream: "#/definitions/tickets"
+          parent_key: "id"
+          partition_field: "id"
+    $parameters:
+      name: "ticket_contacts"
+      primary_key: "id"
+      path: "/tickets/{{ stream_slice.id }}"
+    transformations:
+      - type: AddFields
+        fields:
+          - path: ["ticket_id"]
+            value: "'{{ stream_slice.id }}'"
+    retriever:
+      $ref: "#/definitions/substream_semi_incremental/retriever"
+      record_selector:
+        $ref: "#/definitions/substream_semi_incremental/retriever/record_selector"
+        extractor:
+          field_path: ["contacts", "contacts"]
 
   # incremental search
   stream_incremental_search:
@@ -381,6 +405,7 @@ streams:
   - "#/definitions/conversation_contacts"
   - "#/definitions/company_segments"
   - "#/definitions/tickets"
+  - "#/definitions/ticket_contacts"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/ticket_contacts.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/ticket_contacts.json
@@ -1,0 +1,18 @@
+{
+    "type": "object",
+    "properties": {
+      "ticket_id": {
+        "type": ["null", "string"]
+        },
+      "type": {
+        "type": ["null", "string"]
+        },
+       "id": {
+        "type": ["null", "string"]
+       },
+       "external_id": {
+        "type": ["null", "string"]
+       }
+    }
+  }
+  


### PR DESCRIPTION
JIRA: https://magnifyio.atlassian.net/browse/MAGPROD-3325

Add ticket_contacts substream so that we can start linking data b/w contacts and tickets to hydrate universal identifiers on the tickets object.


Verification:

Performed an ingest in dev to confirm everything to be working:
<img width="1009" alt="Screenshot 2024-01-31 at 5 50 27 PM" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/118306841/23162821-d324-4778-9f12-e618d0f4f1cf">

(5 records ingested in dev):




