### PR TITLE
Add ability to ingest Slack private channels

### DIFF
--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -100,7 +100,7 @@ class Channels(ChanneledStream):
 
     def request_params(self, **kwargs) -> MutableMapping[str, Any]:
         params = super().request_params(**kwargs)
-        params["types"] = "public_channel"
+        params["types"] = "public_channel,private_channel"
         return params
 
     def parse_response(

--- a/airbyte-integrations/connectors/source-slack/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/conftest.py
@@ -15,7 +15,7 @@ os.environ["REQUEST_CACHE_PATH"] = "REQUEST_CACHE_PATH"
 def conversations_list(requests_mock):
     return requests_mock.register_uri(
         "GET",
-        "https://slack.com/api/conversations.list?limit=1000&types=public_channel",
+        "https://slack.com/api/conversations.list?limit=1000&types=public_channel,private_channel",
         json={
             "channels": [
                 {"name": "advice-data-architecture", "id": 1},


### PR DESCRIPTION
This will allow us to include private channels in the ingested channels list for private channels that our Slack app has been added to. It does not ingest messages from those private channels.

Channels ingested from Airbyte locally:
<img width="1041" alt="image" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/108797277/669365bf-e89e-495b-ab35-2d7faa2214da">

The last one is a private channel which our app has been added to.


Also added an external shared connection (private) and added the Slack app to it and we were able to ingest it as well (bottom one in this list):
<img width="902" alt="image" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/108797277/a5243540-9d20-4cc8-a2b6-08c6f8ba40be">

