### PR TITLE
Add Dockerfile for source-slack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ scan-journal.log
 
 # connectors' cache
 *.sqlite
+
+# ignore bin folder
+**/bin/**

--- a/airbyte-integrations/connectors/source-slack/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.9.11-alpine3.15 as base
+
+# build and load all requirements
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base
+
+
+COPY setup.py ./
+# install necessary packages to a temporary folder
+RUN pip install --prefix=/install .
+
+# build a clean environment
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
+
+# bash is installed for more convenient debugging.
+RUN apk --no-cache add bash
+
+# copy payload code only
+COPY main.py ./
+COPY source_slack ./source_slack
+
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+
+LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.name=airbyte/source-slack


### PR DESCRIPTION
There was no Dockerfile for the source-slack connector which is required to build it with a tag other than dev and push it to ECR.

Also added bin folders to .gitignore as I was getting a load of java build stuff trying to be added to git.

Dockerfile build and subsequent push to ECR worked:
<img width="1515" alt="Pasted Graphic 1" src="https://github.com/Encore-Post-Sales/airbyte-magnify/assets/108797277/1b51dd97-43d6-4610-8e42-b31e6d312173">
