### PR TITLE
feat(source-mongodb-v2): add collection allowlist

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 1.3.0
+  dockerImageTag: 1.3.5
   dockerRepository: airbyte/source-mongodb-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mongodb-v2
   githubIssueLabel: source-mongodb-v2

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
@@ -17,6 +17,7 @@ public class MongoConstants {
   public static final Duration CHECKPOINT_DURATION = DebeziumIteratorConstants.SYNC_CHECKPOINT_DURATION;
   public static final String COLLECTION_STATISTICS_COUNT_KEY = "count";
   public static final String COLLECTION_STATISTICS_STORAGE_SIZE_KEY = "size";
+  public static final String COLLECTIONS_INCLUSION_KEY = "collections";
   public static final String CONNECTION_STRING_CONFIGURATION_KEY = MongoDbDebeziumConstants.Configuration.CONNECTION_STRING_CONFIGURATION_KEY;
   public static final String COUNT_KEY = "count";
   public static final String CREDENTIALS_PLACEHOLDER = MongoDbDebeziumConstants.Configuration.CREDENTIALS_PLACEHOLDER;

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
@@ -111,7 +111,9 @@ public class MongoDbSource extends BaseConnector implements Source {
         final String databaseName = sourceConfig.getDatabaseName();
         final Integer sampleSize = sourceConfig.getSampleSize();
         final boolean isSchemaEnforced = sourceConfig.getEnforceSchema();
-        final List<AirbyteStream> streams = MongoUtil.getAirbyteStreams(mongoClient, databaseName, sampleSize, isSchemaEnforced);
+        final List<String> collections = sourceConfig.filterCollections() ? sourceConfig.getCollections() : null;
+        final List<AirbyteStream> streams = MongoUtil.getAirbyteStreams(mongoClient, databaseName, sampleSize, isSchemaEnforced, 
+            collections);
         return new AirbyteCatalog().withStreams(streams);
       }
     } catch (final IllegalArgumentException e) {

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSourceConfig.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSourceConfig.java
@@ -13,6 +13,7 @@ import static io.airbyte.integrations.source.mongodb.MongoConstants.DEFAULT_AUTH
 import static io.airbyte.integrations.source.mongodb.MongoConstants.DEFAULT_DISCOVER_SAMPLE_SIZE;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.DEFAULT_INITIAL_RECORD_WAITING_TIME_SEC;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.DISCOVER_SAMPLE_SIZE_CONFIGURATION_KEY;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.COLLECTIONS_INCLUSION_KEY;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.INITIAL_RECORD_WAITING_TIME_SEC;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.INVALID_CDC_CURSOR_POSITION_PROPERTY;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.PASSWORD_CONFIGURATION_KEY;
@@ -21,6 +22,9 @@ import static io.airbyte.integrations.source.mongodb.MongoConstants.SCHEMA_ENFOR
 import static io.airbyte.integrations.source.mongodb.MongoConstants.USERNAME_CONFIGURATION_KEY;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.OptionalInt;
 
 /**
@@ -88,6 +92,23 @@ public record MongoDbSourceConfig(JsonNode rawConfig) {
   public boolean getEnforceSchema() {
     return getDatabaseConfig().has(SCHEMA_ENFORCED_CONFIGURATION_KEY) ? getDatabaseConfig().get(SCHEMA_ENFORCED_CONFIGURATION_KEY).asBoolean(true)
         : true;
+  }
+
+  public boolean filterCollections() {
+    return rawConfig.has(COLLECTIONS_INCLUSION_KEY) && rawConfig.get(COLLECTIONS_INCLUSION_KEY).isArray() && rawConfig.get(COLLECTIONS_INCLUSION_KEY).size() > 0;
+  }
+
+  public List<String> getCollections() {
+     if ( !filterCollections()) {
+      return Collections.emptyList();
+     }
+
+    ArrayList<String> collections = new ArrayList<String>();
+      for (final JsonNode collection : rawConfig.get(COLLECTIONS_INCLUSION_KEY)) {
+        collections.add(collection.asText());
+      }
+
+    return collections;
   }
 
   public Integer getInitialWaitingTimeSeconds() {

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoUtil.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoUtil.java
@@ -123,14 +123,21 @@ public class MongoUtil {
    *        unique fields for a collection.
    * @param isSchemaEnforced True if the connector is running in schema mode, false if running in
    *        schemaless (packed) mode
+   * @param collections The list of collections to include in the discovery process. If null or empty, all
    * @return The list of {@link AirbyteStream}s that map to the available collections in the provided
    *         database.
    */
   public static List<AirbyteStream> getAirbyteStreams(final MongoClient mongoClient,
                                                       final String databaseName,
                                                       final Integer sampleSize,
-                                                      final boolean isSchemaEnforced) {
+                                                      final boolean isSchemaEnforced,
+                                                      final List<String> collections) {
     final Set<String> authorizedCollections = getAuthorizedCollections(mongoClient, databaseName);
+
+    if ( collections != null && !collections.isEmpty() ) {
+      authorizedCollections.removeIf(c -> !collections.contains(c));
+    }
+
     return authorizedCollections.parallelStream()
         .map(collectionName -> discoverFields(collectionName, mongoClient, databaseName, sampleSize, isSchemaEnforced))
         .filter(Optional::isPresent)

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
@@ -176,6 +176,19 @@
         "default": "Fail sync",
         "order": 11,
         "group": "advanced"
+      },
+      "collections": {
+          "title": "Collections",
+          "description": "The list of collections (case sensitive) to sync. Defaults to all.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "order": 12,
+          "group": "advanced"
       }
     },
     "groups": [


### PR DESCRIPTION
initial schema discovery was observed to timeout against some large connections; the aggregation pipeline failed to return in a timely manner. this allows for specific selection of collections to avoid that issue.