### PR TITLE
Fix Source Pendo Python primary key

### DIFF
--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
@@ -7,7 +7,7 @@ from airbyte_cdk.sources.streams.http import HttpStream
 
 class PendoPythonStream(HttpStream, ABC):
     url_base = "https://app.pendo.io/api/v1/"
-    primary_key = "id"
+    primary_key = None
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         return None


### PR DESCRIPTION
Fix Pendo Python issue where streams didn't have the id primary key. Instead, I'm just removing the primary key specification all together except for the specific hard coded streams.