### PR TITLE
Disable Pendo reports syncs

### DIFF
--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/source.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/source.py
@@ -14,8 +14,8 @@ from .streams import (
     Feature,
     Guide,
     Page,
-    Report,
-    ReportResult,
+    # Report,
+    # ReportResult,
     VisitorMetadata,
     AccountMetadata,
     Visitor,
@@ -67,7 +67,7 @@ class SourcePendoPython(AbstractSource):
             Feature(authenticator=auth),
             Guide(authenticator=auth),
             Page(authenticator=auth),
-            Report(authenticator=auth),
+            # Report(authenticator=auth),
             VisitorMetadata(authenticator=auth),
             AccountMetadata(authenticator=auth),
             Visitor(authenticator=auth),
@@ -77,8 +77,8 @@ class SourcePendoPython(AbstractSource):
             GuideEvents(authenticator=auth)
         ]
 
-        all_reports = self.get_reports(config)
-        for report in all_reports:
-            result.append(ReportResult(report=report, authenticator=auth))
+        # all_reports = self.get_reports(config)
+        # for report in all_reports:
+        #     result.append(ReportResult(report=report, authenticator=auth))
 
         return result


### PR DESCRIPTION
## What
Disable pendo reports syncs for now as we are debugging new strategies to ingest reports. 

## How
Commenting out reports from the available streams to look for 

## Review guide
<img width="1728" alt="image" src="https://github.com/airbytehq/airbyte/assets/106612850/56ab685c-90c6-410d-a612-3817f033ef7a">


## User Impact
Reports wont be synced. 

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
