### PR TITLE
Fix Pendo primary key wrapped in quotes

### DIFF
--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
@@ -96,6 +96,8 @@ class PendoAggregationStream(PendoPythonStream):
         }
 
         if next_page_token is not None:
+            # Some primary keys are already wrapped in quotation marks - strip them when building filter query
+            next_page_token = next_page_token.strip('"')
             request_body["request"]["pipeline"].insert(2, {"filter": f'{self.primary_key} > "{next_page_token}"'})
 
         return request_body


### PR DESCRIPTION
Some primary keys were already wrapped in quotes, breaking a pagination filter query.