### PR TITLE
Add SuiteQL to Netsuite

### DIFF
--- a/airbyte-integrations/connectors/source-netsuite/setup.py
+++ b/airbyte-integrations/connectors/source-netsuite/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk",
+    "airbyte-cdk~=0.2",
     "requests-oauthlib",
 ]
 

--- a/airbyte-integrations/connectors/source-netsuite/source_netsuite/constraints.py
+++ b/airbyte-integrations/connectors/source-netsuite/source_netsuite/constraints.py
@@ -7,6 +7,7 @@
 REST_PATH: str = "/services/rest/"
 RECORD_PATH: str = REST_PATH + "record/v1/"
 META_PATH: str = RECORD_PATH + "metadata-catalog/"
+SUITEQL_PATH: str = "/services/rest/query/v1/suiteql"
 
 # PREDEFINE REFERAL SCHEMA LINK, TEMPLATE
 REFERAL_SCHEMA_URL: str = "/services/rest/record/v1/metadata-catalog/nsLink"
@@ -41,3 +42,38 @@ CUSTOM_INCREMENTAL_CURSOR: str = "lastmodified"
 
 NETSUITE_INPUT_DATE_FORMATS: list[str] = ["%m/%d/%Y", "%Y-%m-%d"]
 NETSUITE_OUTPUT_DATETIME_FORMAT: str = "%Y-%m-%dT%H:%M:%SZ"
+
+INVOICE_CLOSEDATE_SCHEMA: dict = {
+  'type': 'object',
+  'properties': {
+    'closedate': {
+      'title': 'Close Date',
+      'type': 'string',
+      'description': 'A close date',
+      'format': 'date',
+      'nullable': True
+    },
+    'duedate': {
+      'title': 'Due Date',
+      'type': 'string',
+      'description': 'Type or pick the due date for this invoice. If you do not assign a due date, the due date defaults to the date in the Date field. In addition, if you do not assign a due date, this invoice will appear on aging reports.',
+      'format': 'date',
+      'nullable': True
+    },
+    'id': {
+      'title': 'Internal ID',
+      'type': 'string',
+      'nullable': True
+    },
+  },
+  '$schema': 'http://json-schema.org/draft-06/hyper-schema#',
+  'x-ns-filterable': [
+    'closedate',
+    'duedate',
+    'id'
+  ]
+}
+
+SUITEQL_SCHEMAS: dict = {
+    'invoice_closedate': INVOICE_CLOSEDATE_SCHEMA
+}


### PR DESCRIPTION
Adds SuiteQL streams to NetSuite. Image has been pushed to 495303562198.dkr.ecr.us-west-2.amazonaws.com/airbyte-connector-source-netsuite:1.0.0. Tested in local Airbyte and was able to sync data to s3.

The stream is id, closedate, duedate, where id joins to the current invoice stream being pulled by Airbyte.

A few caveats:
1. We need to define the exact schema for the stream we are interested in. I don't believe there is an API to pull this metadata. This will be rough to scale for future cutomers.
2. It currently only supports full refresh. It definitely is possible to make this incremental, but in the interest of time and the lack of knowledge this isn't implemented yet.