### PR TITLE
Specify hardcoded schema for Mongo streams

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/README.md
+++ b/airbyte-integrations/connectors/source-mongodb-v2/README.md
@@ -1,5 +1,27 @@
 # MongoDb Source
 
+## Schema
+
+For each collection, if you want to define a schema in order to propagate type the destination, specify the schema for the collection as a unique string. 
+
+Example:
+
+{"embedded_movies":{"fields":[{"name":"_id","type":"string"},{"name":"tomatoes","type":"object","subfields":[{"name":"production","type":"string"}]}]}}
+
+This means that the collection `embedded_movies` has a schema with a field `_id` of type `string` and a field `tomatoes` of type `object` with a subfield `production` of type `string`.
+
+Valid types are:
+private static JsonSchemaType convertToSchemaType(final String type) {
+    return switch (type) {
+      case "boolean" -> JsonSchemaType.BOOLEAN;
+      case "int", "long", "double", "decimal" -> JsonSchemaType.NUMBER;
+      case "array" -> JsonSchemaType.ARRAY;
+      case "object", "javascriptWithScope" -> JsonSchemaType.OBJECT;
+      case "null" -> JsonSchemaType.NULL;
+      default -> JsonSchemaType.STRING;
+    };
+  }
+
 ## Documentation
 This is the repository for the MongoDb source connector in Java.
 For information about how to use this connector within Airbyte, see [User Documentation](https://docs.airbyte.io/integrations/sources/mongodb-v2)

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
@@ -25,6 +25,7 @@ public class MongoConstants {
   public static final String DATABASE_CONFIG_CONFIGURATION_KEY = MongoDbDebeziumConstants.Configuration.DATABASE_CONFIG_CONFIGURATION_KEY;
   public static final String DEFAULT_AUTH_SOURCE = "admin";
   public static final Integer DEFAULT_DISCOVER_SAMPLE_SIZE = 10000;
+  public static final String SCHEMA_CONFIGURATION_KEY = "schema";
   public static final String DISCOVER_SAMPLE_SIZE_CONFIGURATION_KEY = "discover_sample_size";
   public static final String DRIVER_NAME = "Airbyte";
   public static final String ID_FIELD = "_id";

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
@@ -26,6 +26,7 @@ import io.airbyte.integrations.source.mongodb.state.MongoDbStateManager;
 import io.airbyte.protocol.models.v0.*;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,8 +113,9 @@ public class MongoDbSource extends BaseConnector implements Source {
         final Integer sampleSize = sourceConfig.getSampleSize();
         final boolean isSchemaEnforced = sourceConfig.getEnforceSchema();
         final List<String> collections = sourceConfig.filterCollections() ? sourceConfig.getCollections() : null;
+        final JsonNode schemas = sourceConfig.hasSchema() ? sourceConfig.getSchema() : null;
         final List<AirbyteStream> streams = MongoUtil.getAirbyteStreams(mongoClient, databaseName, sampleSize, isSchemaEnforced, 
-            collections);
+            collections, schemas);
         return new AirbyteCatalog().withStreams(streams);
       }
     } catch (final IllegalArgumentException e) {

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoField.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoField.java
@@ -6,6 +6,8 @@ package io.airbyte.integrations.source.mongodb;
 
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
+
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -17,6 +19,10 @@ public class MongoField extends Field {
 
   public MongoField(final String name, final JsonSchemaType type) {
     super(name, type);
+  }
+
+  public MongoField(final String name, final JsonSchemaType type, final List<Field> subFields) {
+    super(name, type, subFields);
   }
 
   public boolean equals(Object o) {

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
@@ -189,6 +189,13 @@
           "default": [],
           "order": 12,
           "group": "advanced"
+      },
+      "schema": {
+          "title": "Schema",
+          "description": "Hardcoded schema for a stream. If matched with a stream name, will force the schema to confirm to this.",
+          "type": "string",
+          "default": "",
+          "group": "advanced"
       }
     },
     "groups": [


### PR DESCRIPTION
Usage is in the readme.

For each stream you'd like a hardcoded schema pass it in the list of schema 

Pushed newest version to airbyte-connector-source-mongodb-v2/magnify-1.3.7