### PR TITLE
write source sync mode as glue table property

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/MetastoreOperations.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/MetastoreOperations.java
@@ -6,11 +6,12 @@ package io.airbyte.integrations.destination.s3_glue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.cdk.integrations.destination.s3.S3DestinationConfig;
+import io.airbyte.protocol.models.v0.SyncMode;
 
 // TODO (itaseskii) allow config based implementation of different metastores i.e Hive, Nessie, etc.
 public interface MetastoreOperations extends AutoCloseable {
 
-  void upsertTable(String databaseName, String tableName, String location, JsonNode jsonSchema, String serializationLibrary, S3DestinationConfig s3DestinationConfig);
+  void upsertTable(String databaseName, String tableName, String location, JsonNode jsonSchema, String serializationLibrary, S3DestinationConfig s3DestinationConfig, SyncMode syncMode);
 
   void deleteTable(String databaseName, String tableName);
 

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
@@ -101,7 +101,7 @@ public class S3GlueConsumerFactory {
         throw new RuntimeException("Unknown sync mode: " + sourceSyncMode);
       }
       final S3GlueWriteConfig writeConfig =
-          new S3GlueWriteConfig(namespace, streamName, bucketPath, customOutputFormat, fullOutputPath, syncMode, jsonSchema, location);
+          new S3GlueWriteConfig(namespace, streamName, bucketPath, customOutputFormat, fullOutputPath, syncMode, jsonSchema, location, sourceSyncMode);
       return writeConfig;
     };
   }
@@ -177,7 +177,7 @@ public class S3GlueConsumerFactory {
         for (final S3GlueWriteConfig writeConfig : writeConfigs) {
           metastoreOperations.upsertTable(glueDestinationConfig.getDatabase(),
               writeConfig.getStreamName(), writeConfig.getLocation(), writeConfig.getJsonSchema(),
-              glueDestinationConfig.getSerializationLibrary(), s3DestinationConfig);
+              glueDestinationConfig.getSerializationLibrary(), s3DestinationConfig, writeConfig.getSourceSyncMode());
         }
       }
     };

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueDestination.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueDestination.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.airbyte.protocol.models.v0.SyncMode;
 
 public class S3GlueDestination extends BaseS3Destination {
 
@@ -51,7 +52,7 @@ public class S3GlueDestination extends BaseS3Destination {
     String tableName = "test_table_" + tableSuffix;
     try {
       metastoreOperations = new GlueOperations(glueConfig.getAWSGlueInstance());
-      metastoreOperations.upsertTable(glueConfig.getDatabase(), tableName, "s3://", Jsons.emptyObject(), glueConfig.getSerializationLibrary(), s3Config);
+      metastoreOperations.upsertTable(glueConfig.getDatabase(), tableName, "s3://", Jsons.emptyObject(), glueConfig.getSerializationLibrary(), s3Config, SyncMode.FULL_REFRESH);
 
       return new AirbyteConnectionStatus().withStatus(AirbyteConnectionStatus.Status.SUCCEEDED);
     } catch (Exception e) {

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueWriteConfig.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueWriteConfig.java
@@ -4,8 +4,10 @@
 
 package io.airbyte.integrations.destination.s3_glue;
 
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.cdk.integrations.destination.s3.WriteConfig;
+import io.airbyte.protocol.models.v0.SyncMode;
 import io.airbyte.protocol.models.v0.DestinationSyncMode;
 
 public class S3GlueWriteConfig extends WriteConfig {
@@ -14,6 +16,8 @@ public class S3GlueWriteConfig extends WriteConfig {
 
   private final String location;
 
+  private final SyncMode sourceSyncMode;
+
   public S3GlueWriteConfig(String namespace,
                            String streamName,
                            String outputBucketPath,
@@ -21,10 +25,12 @@ public class S3GlueWriteConfig extends WriteConfig {
                            String fullOutputPath,
                            DestinationSyncMode syncMode,
                            JsonNode jsonSchema,
-                           String location) {
+                           String location,
+                           SyncMode sourceSyncMode) {
     super(namespace, streamName, outputBucketPath, pathFormat, fullOutputPath, syncMode);
     this.jsonSchema = jsonSchema;
     this.location = location;
+    this.sourceSyncMode = sourceSyncMode;
   }
 
   public JsonNode getJsonSchema() {
@@ -33,6 +39,10 @@ public class S3GlueWriteConfig extends WriteConfig {
 
   public String getLocation() {
     return location;
+  }
+
+  public SyncMode getSourceSyncMode() {
+    return sourceSyncMode;
   }
 
 }


### PR DESCRIPTION

Write the source sync mode (e.g. full_refresh, incremental) as a glue table property.  Tested in development.  