### PR TITLE
Gainsight Rate Limiting Support

### DIFF
--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
@@ -2,21 +2,14 @@
   "streams": [
     {
       "stream": {
-        "name": "customers",
+        "name": "company",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh"]
+        "supported_sync_modes": [
+          "full_refresh"
+        ]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
-    },
-    {
-      "stream": {
-        "name": "employees",
-        "json_schema": {},
-        "supported_sync_modes": ["full_refresh", "incremental"]
-      },
-      "sync_mode": "incremental",
-      "destination_sync_mode": "append"
     }
   ]
 }


### PR DESCRIPTION
## What

Gainsight supports 100 api calls per minute. While running discover schema, we noticed for some connection instances it's running into rate limiting problem where it's exceeding this number of calls it can make per minute. 

## How

- Adds sleep for a minute if the rate limiting error is identified while running discover schema. 

## Testing 

- Tested by running `python main.py discover --config secrets/config.json` locally. 
