### PR TITLE
(source-marketo): update authentication header retrieval in Leads class

### DIFF
--- a/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
+++ b/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
@@ -388,12 +388,12 @@ class Leads(MarketoExportBase):
             return Leads._schema_cache
 
         standard_properties = super().get_json_schema()
-        resp = self._session.get(f"{self._url_base}rest/v1/leads/describe.json", headers=self.authenticator.get_auth_header())
+        resp = self._session.get(f"{self._url_base}rest/v1/leads/describe.json", headers=self._session.auth.get_auth_header())
         fields = resp.json().get("result")
         if fields is None:
             self.logger.info('retrying to get fields, sleeping 10 seconds...')
             sleep(10)
-            resp = self._session.get(f"{self._url_base}rest/v1/leads/describe.json", headers=self.authenticator.get_auth_header())
+            resp = self._session.get(f"{self._url_base}rest/v1/leads/describe.json", headers=self._session.auth.get_auth_header())
             fields = resp.json().get("result")
             self.logger.info('retried retriving fields')
         


### PR DESCRIPTION
## What
[MAGPROD:6179](https://magnifyio.atlassian.net/browse/MAGPROD-6179)

source-marketo is resulting in partial syncs due to sync failure while attempting to sync the Leads object. I identified the issue in the Flosum airbyte instance. 

## How
- updates the Lead object to pass in the authenticator as expected! 

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
