### PR TITLE
[MAGPROD-6188] Add Iterable Custom Schema Generation

### DIFF
--- a/airbyte-integrations/connectors/source-iterable/source_iterable/components.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/components.py
@@ -2,12 +2,17 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping
 
 import requests
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
-
+from airbyte_cdk.sources.declarative.requesters.http_requester import HttpRequester
+from airbyte_cdk.sources.declarative.schema.schema_loader import SchemaLoader
+from airbyte_cdk.sources.declarative.auth.token import ApiKeyAuthenticator
+from airbyte_cdk.sources.declarative.requesters.request_option import RequestOption, RequestOptionType
+from airbyte_cdk.sources.declarative.auth.token_provider import TokenProvider
+from airbyte_cdk.sources.types import Config
 
 @dataclass
 class EventsRecordExtractor(DpathExtractor):
@@ -20,3 +25,158 @@ class EventsRecordExtractor(DpathExtractor):
             for field in self.common_fields:
                 record_dict_common_fields[field] = record_dict.pop(field, None)
             yield {**record_dict_common_fields, "data": record_dict}
+
+@dataclass
+class IterableTokenProvider(TokenProvider):
+    config: Config
+
+    def get_token(self) -> str:
+        return self.config["api_key"]
+
+@dataclass
+class UsersSchemaLoader(SchemaLoader):
+    config: Config
+    name: str = "users"
+
+    objects: Mapping[str, Any] = field(default_factory=dict)
+
+    def _get_field_schema(self, field_type: str) -> Mapping[str, Any]:
+        match field_type:
+            case "string":
+                return {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            case "date":
+                return {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "format": "date-time"
+                }
+            case "long":
+                return {
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                }
+            case "double":
+                return {
+                    "type": [
+                        "null",
+                        "number"
+                    ]}
+            case "boolean":
+                return {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
+                }
+            case "geo_location":
+                return {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "properties": {
+                        "lat": {
+                            "type": [
+                                "null",
+                                "number"
+                            ]
+                        },
+                        "lon": {
+                            "type": [
+                                "null",
+                                "number"
+                            ]
+                        }
+                    }
+                }
+            case "object":
+                return {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "properties": {}
+                }
+            case _:
+                raise Exception(f"Unknown field type: {field_type}")
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        schema = {
+            "properties": {},
+            "type": ["null", "object"]
+        }
+
+        # Setup the requester to be able to get the fields from the Iterable API
+        request_option = RequestOption(field_name="Api-Key", inject_into=RequestOptionType.header, parameters={})
+        token_provider = IterableTokenProvider(config=self.config)
+        authenticator = ApiKeyAuthenticator(config=self.config, request_option=request_option, token_provider=token_provider, parameters={})
+
+        # Get the fields from the Iterable API
+        requester = HttpRequester(
+            name="users_get_fields",
+            config=self.config,
+            parameters={"name": self.name},
+            url_base="https://api.iterable.com/api/",
+            path="users/getFields",
+            http_method="GET",
+            authenticator=authenticator,
+        )
+
+        response = requester.send_request()
+
+        if not response.ok:
+            raise Exception(f"Failed to get fields from Iterable API: {response.text}")
+
+        fields = response.json().get("fields", {})
+
+        if not fields:
+            raise Exception("No fields found in Iterable API")
+
+        # Sort and iterate through the fields to build the schema
+        for field_name, field_type in sorted(fields.items()):
+            # Split up field names with periods to determine if this is a nested field/object
+            path_parts = field_name.split('.')
+
+            if len(path_parts) > 1:
+                # We are dealing with a nested field or object
+                parent_path = path_parts[:-1]
+                child_field_name = path_parts[-1]
+
+                # Start at the top-level objects and traverse down to the direct parent of the field/object
+                current_level_obj = self.objects
+                parent_obj = None
+                for part in parent_path:
+                    if isinstance(current_level_obj, dict) and part in current_level_obj:
+                        parent_obj = current_level_obj[part]
+                        current_level_obj = parent_obj.get("properties", {})
+
+                        continue
+
+                    raise Exception(f"Parent object at path '{'.'.join(parent_path)}' not found for field '{field_name}'.")
+
+                # Add the field/object to the parent object
+                parent_obj["properties"][child_field_name] = self._get_field_schema(field_type)
+
+                continue
+
+            # We are dealing with a top-level field or object
+            if field_type == "object":
+                # Add the base object schema
+                self.objects[field_name] = self._get_field_schema(field_type)
+            else:
+                schema["properties"][field_name] = self._get_field_schema(field_type)
+
+        # Last step is to add the processed objects to the schema
+        for object_name, object_schema in self.objects.items():
+            schema["properties"][object_name] = object_schema
+
+        return schema

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/manifest.yaml
@@ -13,7 +13,7 @@ spec:
         type: "string"
         title: "API Key"
         description: >-
-          Iterable API Key. See the <a href=\"https://docs.airbyte.com/integrations/sources/iterable\">docs</a> 
+          Iterable API Key. See the <a href=\"https://docs.airbyte.com/integrations/sources/iterable\">docs</a>
           for more information on how to obtain this key.
         airbyte_secret: true
         order: 0
@@ -21,7 +21,7 @@ spec:
         type: "string"
         title: "Start Date"
         description: >-
-          The date from which you'd like to replicate data for Iterable, in the format YYYY-MM-DDT00:00:00Z. 
+          The date from which you'd like to replicate data for Iterable, in the format YYYY-MM-DDT00:00:00Z.
           All data generated after this date will be replicated.
         examples: ["2021-04-01T00:00:00Z"]
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
@@ -322,6 +322,9 @@ streams:
       cursor_datetime_formats:
         - "%Y-%m-%d %H:%M:%S %z"
         - "%Y-%m-%dT%H:%M:%S%z"
+    schema_loader:
+      type: CustomSchemaLoader
+      class_name: source_iterable.components.UsersSchemaLoader
   - name: events
     primary_key: []
     retriever:

--- a/airbyte-integrations/connectors/source-iterable/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-iterable/unit_tests/test_components.py
@@ -1,0 +1,247 @@
+import pytest
+import responses
+from source_iterable.components import UsersSchemaLoader
+
+@pytest.fixture
+def iterable_response_string():
+    return {
+        "fields": {
+            "testString": "string",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_string():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testString": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            }
+        }
+    }
+
+@pytest.fixture
+def iterable_response_long():
+    return {
+        "fields": {
+            "testLong": "long",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_long():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testLong": {
+                "type": [
+                    "null",
+                    "number"
+                ]
+            }
+        }
+    }
+
+@pytest.fixture
+def iterable_response_double():
+    return {
+        "fields": {
+            "testDouble": "double",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_double():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testDouble": {
+                "type": [
+                    "null",
+                    "number"
+                ]
+            }
+        }
+    }
+
+@pytest.fixture
+def iterable_response_boolean():
+    return {
+        "fields": {
+            "testBoolean": "boolean",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_boolean():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testBoolean": {
+                "type": [
+                    "null",
+                    "boolean"
+                ]
+            }
+        }
+    }
+
+@pytest.fixture
+def iterable_response_date():
+    return {
+        "fields": {
+            "testDate": "date",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_date():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testDate": {
+                "type": [
+                    "null",
+                    "string"
+                ],
+                "format": "date-time"
+            }
+        }
+    }
+
+@pytest.fixture
+def iterable_response_geo_location():
+    return {
+        "fields": {
+            "testGeolocation": "geo_location",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_geo_location():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testGeolocation": {
+                "type": [
+                    "null",
+                    "object"
+                ],
+                "properties": {
+                    "lat": {
+                        "type": [
+                            "null",
+                            "number"
+                        ]
+                    },
+                    "lon": {
+                        "type": [
+                            "null",
+                            "number"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+@pytest.fixture
+def iterable_response_object():
+    return {
+        "fields": {
+            "testObject": "object",
+            "testObject.testString": "string",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_object():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testObject": {
+                "type": [
+                    "null",
+                    "object"
+                ],
+                "properties": {
+                    "testString": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                }
+            }
+        }
+    }
+
+@pytest.fixture
+def iterable_response_object_and_sub_object():
+    return {
+        "fields": {
+            "testObject": "object",
+            "testObject.subObject": "object",
+            "testObject.subObject.testString": "string",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_object_and_sub_object():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testObject": {
+                "type": [
+                    "null",
+                    "object"
+                ],
+                "properties": {
+                    "subObject": {
+                        "type": [
+                            "null",
+                            "object"
+                        ],
+                        "properties": {
+                            "testString": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+@pytest.mark.parametrize("api_response_fixture,expected_schema_fixture", [
+    ("iterable_response_string", "expected_schema_string"),
+    ("iterable_response_long", "expected_schema_long"),
+    ("iterable_response_double", "expected_schema_double"),
+    ("iterable_response_boolean", "expected_schema_boolean"),
+    ("iterable_response_date", "expected_schema_date"),
+    ("iterable_response_geo_location", "expected_schema_geo_location"),
+    ("iterable_response_object", "expected_schema_object"),
+    ("iterable_response_object_and_sub_object", "expected_schema_object_and_sub_object"),
+])
+@responses.activate
+def test_users_schema_loader_with_data_types(config, api_response_fixture, expected_schema_fixture, request):
+    """Test UsersSchemaLoader with various data types."""
+    api_response = request.getfixturevalue(api_response_fixture)
+    expected_schema = request.getfixturevalue(expected_schema_fixture)
+
+    responses.get(
+        "https://api.iterable.com/api/users/getFields",
+        json=api_response,
+        status=200,
+    )
+
+    schema_loader = UsersSchemaLoader(config=config, name="users")
+
+    assert schema_loader.get_json_schema() == expected_schema


### PR DESCRIPTION
## What

This PR adds a schema generator for the Iterable users stream based on the outut of the `/users/getFields` API that Iterable supports.

## How

- Adds a `CustomSchemaLoader` definition to the User Stream Manifest file.
- Creates a `UsersSchemaLoader` class within the Components file that loads the Iterable fields definition.
- Adds a `test_components` file with tests for the new custom schema generator.

**NOTE**: The schema generator does not support fields with Array / Nested type as there is no Array type metadata provided by the `getFields` endpoint.

## Can this PR be safely reverted and rolled back?

✅ Yes

