### PR TITLE
[MAGPROD-6188] Update Iterable User Schema Generation

### DIFF
--- a/airbyte-integrations/connectors/source-iterable/source_iterable/components.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/components.py
@@ -115,7 +115,12 @@ class UsersSchemaLoader(SchemaLoader):
                     "properties": {}
                 }
             case _:
-                raise Exception(f"Unknown field type: {field_type}")
+                return {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
 
     def get_json_schema(self) -> Mapping[str, Any]:
         schema = {

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/components.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/components.py
@@ -98,6 +98,14 @@ class UsersSchemaLoader(SchemaLoader):
                         }
                     }
                 }
+            case "nested":
+                return {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "properties": {}
+                }
             case "object":
                 return {
                     "type": [
@@ -169,7 +177,7 @@ class UsersSchemaLoader(SchemaLoader):
                 continue
 
             # We are dealing with a top-level field or object
-            if field_type == "object":
+            if field_type == "object" or field_type == "nested":
                 # Add the base object schema
                 self.objects[field_name] = self._get_field_schema(field_type)
             else:

--- a/airbyte-integrations/connectors/source-iterable/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-iterable/unit_tests/test_components.py
@@ -3,6 +3,28 @@ import responses
 from source_iterable.components import UsersSchemaLoader
 
 @pytest.fixture
+def iterable_response_unknown():
+    return {
+        "fields": {
+            "testUnknown": "unknown",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_unknown():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testUnknown": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            }
+        }
+    }
+
+@pytest.fixture
 def iterable_response_string():
     return {
         "fields": {
@@ -252,6 +274,7 @@ def expected_schema_nested():
     }
 
 @pytest.mark.parametrize("api_response_fixture,expected_schema_fixture", [
+    ("iterable_response_unknown", "expected_schema_unknown"),
     ("iterable_response_string", "expected_schema_string"),
     ("iterable_response_long", "expected_schema_long"),
     ("iterable_response_double", "expected_schema_double"),

--- a/airbyte-integrations/connectors/source-iterable/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-iterable/unit_tests/test_components.py
@@ -220,6 +220,37 @@ def expected_schema_object_and_sub_object():
         }
     }
 
+@pytest.fixture
+def iterable_response_nested():
+    return {
+        "fields": {
+            "testNested": "nested",
+            "testNested.testString": "string",
+        }
+    }
+
+@pytest.fixture
+def expected_schema_nested():
+    return {
+        "type": ["null", "object"],
+        "properties": {
+            "testNested": {
+                "type": [
+                    "null",
+                    "object"
+                ],
+                "properties": {
+                    "testString": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                }
+            }
+        }
+    }
+
 @pytest.mark.parametrize("api_response_fixture,expected_schema_fixture", [
     ("iterable_response_string", "expected_schema_string"),
     ("iterable_response_long", "expected_schema_long"),
@@ -229,6 +260,7 @@ def expected_schema_object_and_sub_object():
     ("iterable_response_geo_location", "expected_schema_geo_location"),
     ("iterable_response_object", "expected_schema_object"),
     ("iterable_response_object_and_sub_object", "expected_schema_object_and_sub_object"),
+    ("iterable_response_nested", "expected_schema_nested"),
 ])
 @responses.activate
 def test_users_schema_loader_with_data_types(config, api_response_fixture, expected_schema_fixture, request):


### PR DESCRIPTION
## Description

During production release of the connection some errors were encountered around the handling of nested field types.

This PR aims to fix this issue by adding Nested field type support.

This PR also makes unknown field types default to string, to allow the system to continue gracefully with schema generation.
