### PR TITLE
add sync mode to s3-glue-destination path

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 471e5cab-8ed1-49f3-ba11-79c687784737
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.20
   dockerRepository: airbyte/destination-s3-glue
   githubIssueLabel: destination-s3-glue
   icon: s3-glue.svg

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
@@ -83,10 +83,10 @@ public class S3GlueConsumerFactory {
       final String namespace = abStream.getNamespace();
       final String streamName = abStream.getName();
       final String bucketPath = s3Config.getBucketPath();
-      final String customOutputFormat = String.join("/", bucketPath, s3Config.getPathFormat());
+      final SyncMode sourceSyncMode = stream.getSyncMode();
+      final String customOutputFormat = String.join("/", bucketPath, s3Config.getPathFormat().replace("${YEAR}", sourceSyncMode + "_${YEAR}"));
       final String fullOutputPath = storageOperations.getBucketObjectPath(namespace, streamName, SYNC_DATETIME, customOutputFormat);
       final DestinationSyncMode syncMode = stream.getDestinationSyncMode();
-      final SyncMode sourceSyncMode = stream.getSyncMode();
       final JsonNode jsonSchema = abStream.getJsonSchema();
       String location = "s3://" + s3Config.getBucketName() + "/";
       if (sourceSyncMode == SyncMode.FULL_REFRESH) {


### PR DESCRIPTION
Adds the sync mode (one of `full_refresh` or `incremental` to the s3 path.  this then allows us to write a cleanup script to remove older full_refresh sync and prevent incrementals from reading multiple full_refreshs / historical data.

bump version to 0.1.20