### PR TITLE
adds date type mappings

### DIFF
--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -42,7 +42,8 @@ class GainsightCsObjectStream(GainsightCsStream):
         "JSON": ["null", "object"],
         "JSONBOOLEAN": ["null", "boolean"],
         "JSONNUMBER": ["null", "number"],
-        "JSONSTRING": ["null", "string"]
+        "JSONSTRING": ["null", "string"],
+        "DATE": ["null", "date"]
     }
 
     def __init__(self, name: str, authenticator: GainsightCsAuthenticator, **kwargs):


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Since the Date type fields was not present in the mappings, these fields were being casted to string. 

## How
<!--
* Describe how code changes achieve the solution.
-->

At the time of schema refresh, now the date fields will be casted as dates. 

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

streams.py

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

The date fields will be now properly casted. The schemas will need to be refreshed manually to make sure this change is being applied to the customers data. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
