### PR TITLE
fix: Update source-pendo-python for CDK 0.90.0 compatibility

### DIFF
--- a/airbyte-integrations/connectors/source-pendo-python/setup.py
+++ b/airbyte-integrations/connectors/source-pendo-python/setup.py
@@ -6,12 +6,12 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.85.0",
+    "airbyte-cdk~=0.90.0",
     "ujson"
 ]
 
 TEST_REQUIREMENTS = [
-    "airbyte-cdk~=0.85.0",
+    "airbyte-cdk~=0.90.0",
     "requests-mock~=1.9.3",
     "pytest~=6.2",
     "pytest-mock~=3.6.1",

--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/source.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/source.py
@@ -49,17 +49,17 @@ class SourcePendoPython(AbstractSource):
         url = f"{self._url_base(config)}page"
         auth = SourcePendoPython._get_authenticator(config)
         try:
-            session = requests.get(url, headers={auth.auth_header: auth.token})
+            session = requests.get(url, headers=auth.get_auth_header())
             session.raise_for_status()
             return True, None
         except requests.exceptions.RequestException as e:
             return False, e
 
     def get_reports(self, config):
-        url = f"{self._url_base(config)}report"
-        auth = SourcePendoPython._get_authenticator(config)
         try:
-            session = requests.get(url, headers={auth.auth_header: auth.token})
+            url = f"{self._url_base(config)}report"
+            auth = SourcePendoPython._get_authenticator(config)
+            session = requests.get(url, headers=auth.get_auth_header())
             body = session.json()
             return [obj["id"] for obj in body]
         except requests.exceptions.RequestException as e:

--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
@@ -13,8 +13,7 @@ class PendoPythonStream(HttpStream, ABC):
     url_base = None
 
     def __init__(self, authenticator, url_base: str = "https://app.pendo.io/api/v1/", **kwargs):
-        super().__init__(**kwargs)
-        self.authenticator = authenticator
+        super().__init__(authenticator=authenticator, **kwargs)
         self.url_base = url_base
 
     def path(self, **kwargs) -> str:


### PR DESCRIPTION
- Fix HttpStream initialization to pass authenticator parameter correctly
- Update CDK version from 0.85.0 to 0.90.0 in setup.py
- Fix authenticator usage in source.py to use get_auth_header() method
- Remove private authenticator storage as CDK now handles auth internally
- Ensure all manual requests use proper authenticator API


Tested the changes by running check, discover and read locally. 