### PR TITLE
fix(source-intercom): add missing import and correct method call

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
@@ -5,7 +5,7 @@
 from dataclasses import InitVar, dataclass, field
 from functools import wraps
 from time import sleep
-from typing import Any, Iterable, List, Mapping, Optional, Union
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 import requests
 from airbyte_cdk.models import SyncMode
@@ -375,7 +375,7 @@ class ErrorHandlerWithRateLimiter(DefaultErrorHandler):
     @IntercomRateLimiter.balance_rate_limit()
     def interpret_response(self, response_or_exception: Optional[Union[requests.Response, Exception]]) -> ErrorResolution:
         # Check for response.headers to define the backoff time before the next api call
-        return super().interpret_response_status(response_or_exception)
+        return super().interpret_response(response_or_exception)
 
     def get_request_params(
         self,


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

- Import MutableMapping to fix NameError
- Call correct super().interpret_response() method in ErrorHandlerWithRateLimiter

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌


Tested the changes by running the adapter locally. 