### PR TITLE
feat(source-redshift): Add Redshift data type support

### DIFF
--- a/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSourceOperations.java
+++ b/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSourceOperations.java
@@ -9,10 +9,12 @@ import static io.airbyte.cdk.db.jdbc.DateTimeConverter.putJavaSQLTime;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.cdk.db.jdbc.DateTimeConverter;
 import io.airbyte.cdk.db.jdbc.JdbcSourceOperations;
+import io.airbyte.protocol.models.JsonSchemaType;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.JDBCType;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -75,6 +77,28 @@ public class RedshiftSourceOperations extends JdbcSourceOperations {
     // LocalDate must be converted to java.sql.Date. Please see
     // https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-data-type-mapping.html
     preparedStatement.setDate(parameterIndex, Date.valueOf(date));
+  }
+
+  @Override
+  public JsonSchemaType getAirbyteType(final JDBCType jdbcType) {
+    return switch (jdbcType) {
+      case BIT, BOOLEAN -> JsonSchemaType.BOOLEAN;
+      case REAL, FLOAT, DOUBLE, NUMERIC, DECIMAL -> JsonSchemaType.NUMBER;
+      case TINYINT, SMALLINT, INTEGER, BIGINT -> JsonSchemaType.INTEGER;
+      case CHAR, NCHAR, NVARCHAR, VARCHAR, LONGVARCHAR -> JsonSchemaType.STRING;
+      case DATE -> JsonSchemaType.STRING_DATE;
+      case TIME -> JsonSchemaType.STRING_TIME_WITHOUT_TIMEZONE;
+      case TIMESTAMP -> JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE;
+      case TIMESTAMP_WITH_TIMEZONE -> JsonSchemaType.STRING_TIMESTAMP_WITH_TIMEZONE;
+      case TIME_WITH_TIMEZONE -> JsonSchemaType.STRING_TIME_WITH_TIMEZONE;
+      case BLOB, BINARY, VARBINARY, LONGVARBINARY -> JsonSchemaType.STRING_BASE_64;
+      case ARRAY -> JsonSchemaType.ARRAY;
+      case STRUCT -> JsonSchemaType.STRING; // SUPER type often mapped as STRUCT
+      case OTHER -> JsonSchemaType.STRING; // Handle OTHER type (e.g., SUPER, GEOMETRY, custom types)
+      // since column types aren't necessarily meaningful to Airbyte, liberally convert all unrecognised
+      // types to String
+      default -> JsonSchemaType.STRING;
+    };
   }
 
 }


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Without explicit type mappings, the redshift datatypes weren't being properly recognized and converted to the appropriate Airbyte schema types,causing incorrect data type inference during schema discovery.

## How
<!--
* Describe how code changes achieve the solution.
-->

This change adds explicit support for Redshift date and time data types in the source-redshift connector. Previously, the connector relied on the default JDBC type mapping from the parent `JdbcSourceOperations` class, which didn't have an override implementation. This caused issues with properly mapping Redshift's data types to Airbyte schema types:

DATE: Calendar date
TIME: Time without timezone
TIMESTAMP: Timestamp without timezone
TIMESTAMPTZ (TIMESTAMP WITH TIME ZONE): Timestamp with timezone
TIMETZ (TIME WITH TIME ZONE): Time with timezone

## User Impact
Currently, we have 2 active connections to redshift. Refresh schema for both the connections and the metadata needs to be re-generated for the connections. 

## Testing

Created a connection with a test table in redshift-development 

<img width="1116" height="199" alt="image" src="https://github.com/user-attachments/assets/1148ff00-94f5-4712-8df9-7859347aa4bd" />

JIRA: https://magnifyio.atlassian.net/browse/MAGPROD-6905

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
