### PR TITLE
feat(source-gainsight-cs): Set Empty Strings as Null for date fields 

### DIFF
--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -103,7 +103,22 @@ class GainsightCsObjectStream(GainsightCsStream):
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         records = response.json().get("data", {}).get("records", [])
-        yield from records
+        schema = self.get_json_schema()
+        properties = schema.get("properties", {})
+        
+        # Identify date and datetime fields from schema
+        date_fields = [
+            field_name 
+            for field_name, field_schema in properties.items() 
+            if field_schema.get("format") in ["date", "date-time"]
+        ]
+        
+        # Transform empty strings to null for date/datetime fields
+        for record in records:
+            for field_name in date_fields:
+                if field_name in record and record[field_name] == "":
+                    record[field_name] = None
+            yield record
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         data = response.json().get("data", {}).get("records", [])


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

date/datetime fields sometimes contain empty strings "", which aren't valid date values per Airbyte's type system.


## How
<!--
* Describe how code changes achieve the solution.
-->

- Updated parse_response to identify date/datetime fields from the schema
- Convert empty strings to null for those fields before yielding records


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

This resolves the sync error. Fields missing from the response are fine since the schema allows null, and empty strings are now converted to null instead of being treated as invalid date values.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [X] NO ❌
