### PR TITLE
fix(source-pendo-python): add created_date to date normalization

### DIFF
--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
@@ -366,30 +366,36 @@ class Visitor(PendoAggregationStream):
         source = {"visitors": {"identified": True}}
         return self.build_request_body("visitor-list", source, next_page_token)
 
+    def normalize_date(self, date: Any) -> int:
+        if isinstance(date, str):
+        # Handle ISO 8601 strings (e.g., '2019-02-08T21:30:53.150Z')
+            try:
+                parsed_date = pendulum.parse(date, strict=False).in_timezone("UTC")
+                self.logger.info(f"Converted ISO 8601 createdate to milliseconds: {date}")
+                return int(parsed_date.timestamp() * 1000) # Convert to milliseconds
+            except Exception as e:
+                self.logger.error(f"Failed to parse createdate '{date}': {e}")
+                raise ValueError(f"Invalid date format for createdate: {date}")
+        elif isinstance(date, int):
+            # Already in milliseconds
+            return date
+        elif date is None:
+            return None
+        else:
+            # Unexpected type
+            self.logger.warning(f"Unexpected createdate type: {type(date)}, value: {date}")
+            return date
+
     def normalize_createdate(self, record: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         """
         normalize the record dates to milliseconds if metadata.agent.createdate is present
         createdate could be a timestamp in milliseconds after the epoch (UTC) or 
         an ISO 8601 string (e.g., '2019-02-08T21:30:53.150Z')
-        """        
+        """
         if "metadata" in record and "agent" in record["metadata"] and "createdate" in record["metadata"]["agent"]:
-            createdate = record["metadata"]["agent"]["createdate"]
-            if isinstance(createdate, str):
-                # Handle ISO 8601 strings (e.g., '2019-02-08T21:30:53.150Z')
-                try:
-                    parsed_date = pendulum.parse(createdate, strict=False).in_timezone('UTC')
-                    record["metadata"]["agent"]["createdate"] = int(parsed_date.timestamp() * 1000) # Convert to milliseconds
-                    self.logger.info(f"Converted ISO 8601 createdate to milliseconds: {record['metadata']['agent']['createdate']}")
-                except Exception as e:
-                    self.logger.error(f"Failed to parse createdate '{createdate}': {e}")
-                    raise ValueError(f"Invalid date format for createdate: {createdate}")
-            elif isinstance(createdate, int):
-                # Already in milliseconds
-                record["metadata"]["agent"]["createdate"] = createdate
-            else:
-                # Unexpected type
-                self.logger.warning(f"Unexpected createdate type: {type(createdate)}, value: {createdate}")
-                record["metadata"]["agent"]["createdate"] = createdate
+            record["metadata"]["agent"]["createdate"] = self.normalize_date(record["metadata"]["agent"]["createdate"])
+        if "metadata" in record and "agent" in record["metadata"] and "created_date" in record["metadata"]["agent"]:
+            record["metadata"]["agent"]["created_date"] = self.normalize_date(record["metadata"]["agent"]["created_date"])
         return record
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:

--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
@@ -66,9 +66,11 @@ class PendoPythonStream(HttpStream, ABC):
                         fields[field] = {"type": ["null", "integer", "string"]}
                     elif field == "accountnumbersf":
                         fields[field] = {"type": ["null", "string", "number"]}
-                    elif field == "sfpendogolivedate": # sfpendogolivedate can be empty string or datetime string - tenant: modelN
+                    elif field == "sfpendogolivedate": # sfpendogolivedate can be empty string or datetime string - tenant: ten_01k9qy066cfvgv3m14v0zprfd7
                         fields[field] = {"type": ["null", "string", "number"]}
-                    elif field == "sfnpslatest": # sfnpslatest can be empty string with escape character or number - tenant: modelN
+                    elif field == "sfnpslatest": # sfnpslatest can be empty string with escape character or number - tenant: ten_01k9qy066cfvgv3m14v0zprfd7
+                        fields[field] = {"type": ["null", "string", "number"]}
+                    elif field == "sfpendolivedate": # sfpendogolivedate can be empty string or datetime string - tenant: ten_01k9qy066cfvgv3m14v0zprfd7
                         fields[field] = {"type": ["null", "string", "number"]}
                     else:
                         fields[field] = self.get_valid_field_info(field_type)


### PR DESCRIPTION
## What

Adds date normalization to the metadata.agents.created_date field 

I have tested this live and confirmed it to work.  In image tagged released-1.0.9

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
