### PR TITLE
feat(source-gainsight-cs): Incremental Support + Skip records when error in response

### DIFF
--- a/airbyte-integrations/connectors/source-gainsight-cs/README.md
+++ b/airbyte-integrations/connectors/source-gainsight-cs/README.md
@@ -47,6 +47,16 @@ python main.py discover --config secrets/config.json
 python main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json
 ```
 
+**Testing incremental sync locally:**  
+Without `--state`, the connector does a full read (no cursor filter), so you get all records. To test incremental and only fetch records after a cursor:
+
+1. Pass a state file with `--state`. The file must be a JSON **array** of per-stream state messages (see `integration_tests/sample_state.json`).
+2. Example (only records with `Date >= 2026-03-05` for the configured stream):
+```bash
+python main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json --state integration_tests/sample_state.json
+```
+3. To simulate “no new data,” use a far-future cursor in your state file (e.g. `integration_tests/abnormal_state.json`). You should see no records and updated state messages.
+
 ### Locally running the connector docker image
 
 #### Use `airbyte-ci` to build your connector

--- a/airbyte-integrations/connectors/source-gainsight-cs/README.md
+++ b/airbyte-integrations/connectors/source-gainsight-cs/README.md
@@ -6,23 +6,28 @@ For information about how to use this connector within Airbyte, see [the documen
 ## Local development
 
 ### Prerequisites
+
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
 #### Minimum Python version required `= 3.9.0`
 
 #### Activate Virtual Environment and install dependencies
+
 From this connector directory, create a virtual environment:
+
 ```
 python -m venv .venv
 ```
 
 This will generate a virtualenv for this module in `.venv/`. Make sure this venv is active in your
 development environment of choice. To activate it from the terminal, run:
+
 ```
 source .venv/bin/activate
 pip install -r requirements.txt
 pip install '.[tests]'
 ```
+
 If you are in an IDE, follow your IDE's instructions to activate the virtualenv.
 
 Note that while we are installing dependencies from `requirements.txt`, you should only edit `setup.py` for your dependencies. `requirements.txt` is
@@ -30,7 +35,30 @@ used for editable installs (`pip install -e`) to pull in Python dependencies fro
 If this is mumbo jumbo to you, don't worry about it, just put your deps in `setup.py` but install using `pip install -r requirements.txt` and everything
 should work as you expect.
 
+# In event there is a bad env:
+
+# Deactivate the current venv and remove it
+
+```
+deactivate
+rm -rf .venv
+```
+
+# Create a new venv with Python 3.10 (distutils is built-in)
+
+```
+python3.10 -m venv .venv
+source .venv/bin/activate
+```
+
+# Install
+
+```
+pip install -r requirements.txt
+```
+
 #### Create credentials
+
 **If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/gainsight-cs)
 to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_gainsight_cs/spec.yaml` file.
 Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
@@ -40,6 +68,7 @@ See `integration_tests/sample_config.json` for a sample config file.
 and place them into `secrets/config.json`.
 
 ### Locally running the connector
+
 ```
 python main.py spec
 python main.py check --config secrets/config.json
@@ -52,14 +81,17 @@ Without `--state`, the connector does a full read (no cursor filter), so you get
 
 1. Pass a state file with `--state`. The file must be a JSON **array** of per-stream state messages (see `integration_tests/sample_state.json`).
 2. Example (only records with `Date >= 2026-03-05` for the configured stream):
+
 ```bash
 python main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json --state integration_tests/sample_state.json
 ```
+
 3. To simulate “no new data,” use a far-future cursor in your state file (e.g. `integration_tests/abnormal_state.json`). You should see no records and updated state messages.
 
 ### Locally running the connector docker image
 
 #### Use `airbyte-ci` to build your connector
+
 The Airbyte way of building this connector is to use our `airbyte-ci` tool.
 You can follow install instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#L1).
 Then running the following command will build your connector:
@@ -67,15 +99,18 @@ Then running the following command will build your connector:
 ```bash
 airbyte-ci connectors --name source-gainsight-cs build
 ```
+
 Once the command is done, you will find your connector image in your local docker registry: `airbyte/source-gainsight-cs:dev`.
 
 ##### Customizing our build process
+
 When contributing on our connector you might need to customize the build process to add a system dependency or set an env var.
 You can customize our build process by adding a `build_customization.py` module to your connector.
 This module should contain a `pre_connector_install` and `post_connector_install` async function that will mutate the base image and the connector container respectively.
 It will be imported at runtime by our build process and the functions will be called if they exist.
 
 Here is an example of a `build_customization.py` module:
+
 ```python
 from __future__ import annotations
 
@@ -95,6 +130,7 @@ async def post_connector_install(connector_container: Container) -> Container:
 ```
 
 #### Build your own connector image
+
 This connector is built using our dynamic built process in `airbyte-ci`.
 The base image used to build it is defined within the metadata.yaml file under the `connectorBuildOptions`.
 The build logic is defined using [Dagger](https://dagger.io/) [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/pipelines/builds/python_connectors.py).
@@ -103,6 +139,7 @@ It does not rely on a Dockerfile.
 If you would like to patch our connector and build your own a simple approach would be to:
 
 1. Create your own Dockerfile based on the latest version of the connector image.
+
 ```Dockerfile
 FROM airbyte/source-gainsight-cs:latest
 
@@ -113,59 +150,79 @@ RUN pip install ./airbyte/integration_code
 # ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 # ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 ```
+
 Please use this as an example. This is not optimized.
 
 2. Build your image:
+
 ```bash
 docker build -t airbyte/source-gainsight-cs:dev .
 # Running the spec command against your patched connector
 docker run airbyte/source-gainsight-cs:dev spec
-````
+```
 
 #### Run
+
 Then run any of the connector commands as follows:
+
 ```
 docker run --rm airbyte/source-gainsight-cs:dev spec
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-gainsight-cs:dev check --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-gainsight-cs:dev discover --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-gainsight-cs:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
 ```
+
 ## Testing
+
 Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
 First install test dependencies into your virtual environment:
+
 ```
 pip install .[tests]
 ```
+
 ### Unit Tests
+
 To run unit tests locally, from the connector directory run:
+
 ```
 python -m pytest unit_tests
 ```
 
 ### Integration Tests
+
 There are two types of integration tests: Acceptance Tests (Airbyte's test suite for all source connectors) and custom integration tests (which are specific to this connector).
+
 #### Custom Integration tests
+
 Place custom tests inside `integration_tests/` folder, then, from the connector root, run
+
 ```
 python -m pytest integration_tests
 ```
 
 ### Acceptance Tests
+
 Customize `acceptance-test-config.yml` file to configure tests. See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference) for more information.
 If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
 Please run acceptance tests via [airbyte-ci](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#connectors-test-command):
+
 ```bash
 airbyte-ci connectors --name source-gainsight-cs test
 ```
 
 ## Dependency Management
+
 All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.
 We split dependencies between two groups, dependencies that are:
-* required for your connector to work need to go to `MAIN_REQUIREMENTS` list.
-* required for the testing need to go to `TEST_REQUIREMENTS` list
+
+- required for your connector to work need to go to `MAIN_REQUIREMENTS` list.
+- required for the testing need to go to `TEST_REQUIREMENTS` list
 
 ### Publishing a new version of the connector
+
 You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
+
 1. Make sure your changes are passing our test suite: `airbyte-ci connectors --name=source-gainsight-cs test`
 2. Bump the connector version in `metadata.yaml`: increment the `dockerImageTag` value. Please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors).
 3. Make sure the `metadata.yaml` content is up to date.
@@ -173,4 +230,3 @@ You've checked out the repo, implemented a million dollar feature, and you're re
 5. Create a Pull Request: use [our PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention).
 6. Pat yourself on the back for being an awesome contributor.
 7. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.
-

--- a/airbyte-integrations/connectors/source-gainsight-cs/README.md
+++ b/airbyte-integrations/connectors/source-gainsight-cs/README.md
@@ -9,14 +9,16 @@ For information about how to use this connector within Airbyte, see [the documen
 
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
-#### Minimum Python version required `= 3.9.0`
+#### Python version required `>= 3.9.0, <= 3.11.x`
+
+> **Important:** Python 3.12+ is **not supported**. The `pendulum` dependency (pulled in by `airbyte-cdk`) uses `distutils`, which was removed from the standard library in Python 3.12. Use Python 3.11 or earlier.
 
 #### Activate Virtual Environment and install dependencies
 
-From this connector directory, create a virtual environment:
+From this connector directory, create a virtual environment with Python 3.11:
 
 ```
-python -m venv .venv
+python3.11 -m venv .venv
 ```
 
 This will generate a virtualenv for this module in `.venv/`. Make sure this venv is active in your
@@ -35,25 +37,15 @@ used for editable installs (`pip install -e`) to pull in Python dependencies fro
 If this is mumbo jumbo to you, don't worry about it, just put your deps in `setup.py` but install using `pip install -r requirements.txt` and everything
 should work as you expect.
 
-# In event there is a bad env:
+#### Resetting a broken environment
 
-# Deactivate the current venv and remove it
+If you need to start fresh (e.g. you created the venv with the wrong Python version):
 
 ```
 deactivate
 rm -rf .venv
-```
-
-# Create a new venv with Python 3.10 (distutils is built-in)
-
-```
-python3.10 -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
-```
-
-# Install
-
-```
 pip install -r requirements.txt
 ```
 

--- a/airbyte-integrations/connectors/source-gainsight-cs/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-gainsight-cs/acceptance-test-config.yml
@@ -19,20 +19,18 @@ acceptance_tests:
       - config_path: "secrets/config.json"
         configured_catalog_path: "integration_tests/configured_catalog.json"
         empty_streams: []
-# TODO uncomment this block to specify that the tests should assert the connector outputs the records provided in the input file a file
-#        expect_records:
-#          path: "integration_tests/expected_records.jsonl"
-#          extra_fields: no
-#          exact_order: no
-#          extra_records: yes
-  incremental: 
-    bypass_reason: "This connector does not implement incremental sync"
-# TODO uncomment this block this block if your connector implements incremental sync: 
-#    tests:
-#      - config_path: "secrets/config.json"
-#        configured_catalog_path: "integration_tests/configured_catalog.json"
-#        future_state:
-#          future_state_path: "integration_tests/abnormal_state.json"
+  # TODO uncomment this block to specify that the tests should assert the connector outputs the records provided in the input file a file
+  #        expect_records:
+  #          path: "integration_tests/expected_records.jsonl"
+  #          extra_fields: no
+  #          exact_order: no
+  #          extra_records: yes
+  incremental:
+    tests:
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"
+        future_state:
+          future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/abnormal_state.json
@@ -1,5 +1,14 @@
-{
-  "todo-stream-name": {
-    "todo-field-name": "todo-abnormal-value"
+[
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "company",
+        "namespace": null
+      },
+      "stream_state": {
+        "Date": "2999-12-31T00:00:00Z"
+      }
+    }
   }
-}
+]

--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
@@ -5,11 +5,19 @@
         "name": "company",
         "json_schema": {},
         "supported_sync_modes": [
-          "full_refresh"
+          "full_refresh",
+          "incremental"
+        ],
+        "source_defined_cursor": true,
+        "default_cursor_field": [
+          "ModifiedDate"
         ]
       },
-      "sync_mode": "full_refresh",
-      "destination_sync_mode": "overwrite"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": [
+        "ModifiedDate"
+      ]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
@@ -2,7 +2,7 @@
   "streams": [
     {
       "stream": {
-        "name": "company",
+        "name": "activity_timeline",
         "json_schema": {},
         "supported_sync_modes": [
           "full_refresh",
@@ -10,13 +10,13 @@
         ],
         "source_defined_cursor": true,
         "default_cursor_field": [
-          "ModifiedDate"
+          "LastModifiedDate"
         ]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append",
       "cursor_field": [
-        "ModifiedDate"
+        "LastModifiedDate"
       ]
     }
   ]

--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/configured_catalog.json
@@ -2,6 +2,25 @@
   "streams": [
     {
       "stream": {
+        "name": "company",
+        "json_schema": {},
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ],
+        "source_defined_cursor": true,
+        "default_cursor_field": [
+          "ModifiedDate"
+        ]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": [
+        "ModifiedDate"
+      ]
+    },
+    {
+      "stream": {
         "name": "activity_timeline",
         "json_schema": {},
         "supported_sync_modes": [

--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/sample_state.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/sample_state.json
@@ -7,7 +7,7 @@
         "namespace": null
       },
       "stream_state": {
-        "ModifiedDate": "2026-03-04T00:00:00Z"
+        "ModifiedDate": "2020-03-04T00:00:00Z"
       }
     }
   }

--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/sample_state.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/sample_state.json
@@ -1,5 +1,14 @@
-{
-  "todo-stream-name": {
-    "todo-field-name": "value"
+[
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "company",
+        "namespace": null
+      },
+      "stream_state": {
+        "ModifiedDate": "2026-03-04T00:00:00Z"
+      }
+    }
   }
-}
+]

--- a/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/sample_state.json
+++ b/airbyte-integrations/connectors/source-gainsight-cs/integration_tests/sample_state.json
@@ -10,5 +10,17 @@
         "ModifiedDate": "2020-03-04T00:00:00Z"
       }
     }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "activity_timeline",
+        "namespace": null
+      },
+      "stream_state": {
+        "LastModifiedDate": "2023-01-01T00:00:00Z"
+      }
+    }
   }
 ]

--- a/airbyte-integrations/connectors/source-gainsight-cs/setup.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/setup.py
@@ -6,12 +6,12 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.51.0",
+    "airbyte-cdk~=0.90.0",
     "requests",
 ]
 
 TEST_REQUIREMENTS = [
-    "airbyte-cdk~=0.51.0",
+    "airbyte-cdk~=0.90.0",
     "requests-mock~=1.9.3",
     "pytest~=6.2",
     "pytest-mock~=3.6.1",

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/authenticator.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/authenticator.py
@@ -1,6 +1,9 @@
+import logging
 import time
 import requests
 import base64
+
+logger = logging.getLogger(__name__)
 
 
 class GainsightCsAuthenticator(requests.auth.AuthBase):
@@ -34,6 +37,7 @@ class GainsightCsAuthenticator(requests.auth.AuthBase):
 
     def _rotate(self):
         if self._is_token_expired():
+            logger.warning("Access token expired or missing, requesting a new token")
             try:
                 credentials = f"{self._client_id}:{self._client_secret}"
                 encoded_credentials = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
@@ -45,13 +49,23 @@ class GainsightCsAuthenticator(requests.auth.AuthBase):
 
                 response = requests.post(url=url, headers=headers)
                 if response.status_code != 200:
+                    logger.error("Token request failed with status %d: %s", response.status_code, response.text)
                     raise Exception(f"Error fetching access token: {response.text}")
 
                 self._token = response.json()
                 self._token_acquired_at = time.time()
                 self._expires_in = self._token.get("expires_in", 0)
+                logger.warning(
+                    "Access token refreshed successfully, expires in %ds (~%.1fh)",
+                    self._expires_in,
+                    self._expires_in / 3600,
+                )
             except requests.exceptions.RequestException as e:
+                logger.error("Network error while fetching access token: %s", e)
                 raise Exception(f"Error fetching access token: {e}") from e
+        else:
+            seconds_remaining = (self._token_acquired_at + self._expires_in - 60) - time.time()
+            logger.debug("Access token still valid, %.1fs remaining before expiry buffer", seconds_remaining)
 
     def __call__(self, r: requests.Request) -> requests.Request:
         self._rotate()

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/authenticator.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/authenticator.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 import requests
 import base64
@@ -18,6 +19,7 @@ class GainsightCsAuthenticator(requests.auth.AuthBase):
         self._headers = {}
         self._token_acquired_at = None  # Time when token was fetched (in seconds)
         self._expires_in = None  # Token lifetime (in seconds)
+        self._lock = threading.Lock()
 
     @property
     def domain_url(self):
@@ -36,36 +38,37 @@ class GainsightCsAuthenticator(requests.auth.AuthBase):
         return False
 
     def _rotate(self):
-        if self._is_token_expired():
-            logger.warning("Access token expired or missing, requesting a new token")
-            try:
-                credentials = f"{self._client_id}:{self._client_secret}"
-                encoded_credentials = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
-                headers = {
-                    "Authorization": f"Basic {encoded_credentials}",
-                    "Content-Type": "application/json"
-                }
-                url = f"{self._domain_url}{self._token_request_path}"
+        with self._lock:
+            if self._is_token_expired():
+                logger.warning("Access token expired or missing, requesting a new token")
+                try:
+                    credentials = f"{self._client_id}:{self._client_secret}"
+                    encoded_credentials = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
+                    headers = {
+                        "Authorization": f"Basic {encoded_credentials}",
+                        "Content-Type": "application/json"
+                    }
+                    url = f"{self._domain_url}{self._token_request_path}"
 
-                response = requests.post(url=url, headers=headers)
-                if response.status_code != 200:
-                    logger.error("Token request failed with status %d: %s", response.status_code, response.text)
-                    raise Exception(f"Error fetching access token: {response.text}")
+                    response = requests.post(url=url, headers=headers)
+                    if response.status_code != 200:
+                        logger.error("Token request failed with status %d: %s", response.status_code, response.text)
+                        raise Exception(f"Error fetching access token: {response.text}")
 
-                self._token = response.json()
-                self._token_acquired_at = time.time()
-                self._expires_in = self._token.get("expires_in", 0)
-                logger.warning(
-                    "Access token refreshed successfully, expires in %ds (~%.1fh)",
-                    self._expires_in,
-                    self._expires_in / 3600,
-                )
-            except requests.exceptions.RequestException as e:
-                logger.error("Network error while fetching access token: %s", e)
-                raise Exception(f"Error fetching access token: {e}") from e
-        else:
-            seconds_remaining = (self._token_acquired_at + self._expires_in - 60) - time.time()
-            logger.debug("Access token still valid, %.1fs remaining before expiry buffer", seconds_remaining)
+                    self._token = response.json()
+                    self._token_acquired_at = time.time()
+                    self._expires_in = self._token.get("expires_in", 0)
+                    logger.warning(
+                        "Access token refreshed successfully, expires in %ds (~%.1fh)",
+                        self._expires_in,
+                        self._expires_in / 3600,
+                    )
+                except requests.exceptions.RequestException as e:
+                    logger.error("Network error while fetching access token: %s", e)
+                    raise Exception(f"Error fetching access token: {e}") from e
+            else:
+                seconds_remaining = (self._token_acquired_at + self._expires_in - 60) - time.time()
+                logger.debug("Access token still valid, %.1fs remaining before expiry buffer", seconds_remaining)
 
     def __call__(self, r: requests.Request) -> requests.Request:
         self._rotate()

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/authenticator.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/authenticator.py
@@ -25,8 +25,8 @@ class GainsightCsAuthenticator(requests.auth.AuthBase):
         if not self._token or self._token_acquired_at is None or self._expires_in is None:
             return True
 
-        current_time = time.time()  # seconds since epoch
-        # Subtract a buffer (e.g., 60 seconds) to account for network delays.
+        current_time = time.time()
+        # Subtract a 60-second buffer to account for network delays.
         if current_time > self._token_acquired_at + self._expires_in - 60:
             return True
 
@@ -35,7 +35,6 @@ class GainsightCsAuthenticator(requests.auth.AuthBase):
     def _rotate(self):
         if self._is_token_expired():
             try:
-                # Prepare the authorization header with encoded credentials
                 credentials = f"{self._client_id}:{self._client_secret}"
                 encoded_credentials = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
                 headers = {
@@ -63,6 +62,5 @@ class GainsightCsAuthenticator(requests.auth.AuthBase):
         """
         Returns the authorization header with the current access token.
         """
-        if not self._token or 'access_token' not in self._token:
-            self._rotate()
+        self._rotate()
         return {"Authorization": f"Bearer {self._token.get('access_token')}"}

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/source.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/source.py
@@ -15,7 +15,10 @@ from .authenticator import GainsightCsAuthenticator
 class SourceGainsightCs(AbstractSource):
 
     def check_connection(self, logger, config) -> Tuple[bool, any]:
-        authenticator = GainsightCsAuthenticator(config)
+        try:
+            authenticator = GainsightCsAuthenticator(config)
+        except (KeyError, TypeError) as e:
+            return False, f"Invalid configuration: {e}"
         logger.info(f"Checking connection to {authenticator.domain_url}")
         try:
             url = f"{authenticator.domain_url}/v1/meta/services/objects/Person/describe?idd=true"

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/source.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/source.py
@@ -2,7 +2,10 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, List, Mapping, Tuple
+
 import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
@@ -11,6 +14,8 @@ from .streams import (
     GainsightCsObjectStream
 )
 from .authenticator import GainsightCsAuthenticator
+
+logger = logging.getLogger(__name__)
 
 class SourceGainsightCs(AbstractSource):
 
@@ -49,11 +54,31 @@ class SourceGainsightCs(AbstractSource):
         authenticator = GainsightCsAuthenticator(config)
         all_objects = self.get_objects(config)
         lookback_days = config.get("lookback_730_day_streams", [])
-        result = []
+
+        streams_by_name = {}
         for object_name in all_objects:
-            result.append(GainsightCsObjectStream(
+            streams_by_name[object_name] = GainsightCsObjectStream(
                 name=object_name,
                 authenticator=authenticator,
                 lookback_730_day_streams=lookback_days,
-            ))
-        return result
+            )
+
+        authenticator._rotate()
+        base_url = f"{authenticator.domain_url}/v1/meta/services/objects"
+
+        def _fetch_describe(object_name: str):
+            url = f"{base_url}/{object_name}/describe?idd=true"
+            resp = requests.get(url, auth=authenticator)
+            return object_name, resp.json()
+
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            futures = {pool.submit(_fetch_describe, name): name for name in all_objects}
+            for future in as_completed(futures):
+                name = futures[future]
+                try:
+                    _, body = future.result()
+                    streams_by_name[name]._build_schema_from_describe_response(body)
+                except Exception:
+                    logger.warning("Parallel describe fetch failed for '%s'; will fall back to lazy fetch", name, exc_info=True)
+
+        return list(streams_by_name.values())

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/source.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/source.py
@@ -48,7 +48,12 @@ class SourceGainsightCs(AbstractSource):
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         authenticator = GainsightCsAuthenticator(config)
         all_objects = self.get_objects(config)
+        lookback_days = config.get("lookback_730_day_streams", [])
         result = []
         for object_name in all_objects:
-            result.append(GainsightCsObjectStream(name=object_name, authenticator=authenticator))
+            result.append(GainsightCsObjectStream(
+                name=object_name,
+                authenticator=authenticator,
+                lookback_730_day_streams=lookback_days,
+            ))
         return result

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/spec.yaml
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/spec.yaml
@@ -20,4 +20,15 @@ connectionSpecification:
       type: string
       title: Client Secret
       airbyte_secret: true
+    lookback_730_day_streams:
+      type: array
+      title: Lookback 730 Day Streams
+      description: >
+        List of stream/object names that should look back 730 days on the first
+        incremental sync (when there is no prior state). Streams not listed will
+        perform a full scan on first sync.
+      items:
+        type: string
+      examples:
+        - ["time_series_daily"]
   additionalProperties: true

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -50,7 +50,7 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
         "JSONSTRING": ["null", "string"]
     }
 
-    def __init__(self, name: str, authenticator: GainsightCsAuthenticator, **kwargs):
+    def __init__(self, name: str, authenticator: GainsightCsAuthenticator, lookback_730_day_streams: Optional[List[str]] = None, **kwargs):
         super().__init__(authenticator, **kwargs)
         self.object_name = name
         self._primary_key = None
@@ -58,6 +58,7 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
         self._cursor_field_override: Optional[str] = None
         self._current_slice: Optional[Mapping[str, Any]] = None
         self._state: MutableMapping[str, Any] = {}
+        self._lookback_730_day_streams: List[str] = lookback_730_day_streams or []
 
     @property
     def state(self) -> MutableMapping[str, Any]:
@@ -151,24 +152,32 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
 
         start_str = (stream_state or {}).get(cursor_name)
 
-        # First sync with no prior state: full scan, one STATE checkpoint at end
         if not start_str:
+            if self.object_name in self._lookback_730_day_streams:
+                lookback_days = 730
+            else:
+                # First sync with no prior state: full scan, one STATE checkpoint at end
+                self.logger.info(
+                    "Stream '%s': incremental with cursor '%s', no prior state — full scan (single slice)",
+                    self.object_name, cursor_name,
+                )
+                yield {}
+                return
             self.logger.info(
-                "Stream '%s': incremental with cursor '%s', no prior state — full scan (single slice)",
-                self.object_name, cursor_name,
+                "Stream '%s': incremental with cursor '%s', no prior state — limiting to last %d days",
+                self.object_name, cursor_name, lookback_days,
             )
-            yield {}
-            return
-
-        try:
-            start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
-        except (ValueError, AttributeError):
-            self.logger.info(
-                "Stream '%s': could not parse state for cursor '%s' (value: %s), yielding single full-scan slice",
-                self.object_name, cursor_name, start_str,
-            )
-            yield {}
-            return
+            start_dt = datetime.now(tz=timezone.utc) - timedelta(days=lookback_days)
+        else:
+            try:
+                start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                self.logger.info(
+                    "Stream '%s': could not parse state for cursor '%s' (value: %s), yielding single full-scan slice",
+                    self.object_name, cursor_name, start_str,
+                )
+                yield {}
+                return
 
         now_dt = datetime.now(tz=timezone.utc)
         delta = timedelta(days=self.SLICE_RANGE_DAYS)
@@ -292,7 +301,7 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
         schema_properties = self.get_json_schema().get("properties", {})
 
         if slice_start and slice_end and cursor_field_name:
-            # Time-window slice: bounded GTE + LT filter with orderBy for deterministic offset pagination
+            # Time-window slice: bounded GTE + LT filter
             if cursor_field_name in schema_properties:
                 body["where"] = {
                     "conditions": [
@@ -301,7 +310,6 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
                     ],
                     "expression": "A AND B",
                 }
-                body["orderBy"] = {cursor_field_name: "asc"}
             else:
                 logger.warning(
                     "Cursor field '%s' not present on object '%s'; skipping incremental filter to avoid API error. Sync will read all records.",
@@ -323,6 +331,9 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
                         cursor_field_name,
                         self.object_name,
                     )
+
+        if cursor_field_name:
+            body["orderBy"] = {cursor_field_name: "asc"}
 
         return body
 

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -119,11 +119,13 @@ class GainsightCsObjectStream(GainsightCsStream):
         stream_state: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ) -> Iterable[Optional[Mapping[str, Any]]]:
+        logger = logging.getLogger(__name__)
         cursor = self.cursor_field
         cursor_name = cursor if isinstance(cursor, str) else (cursor[0] if cursor else None)
 
         # No cursor field or full refresh: single slice, no time bounds (existing full-scan behavior)
         if not cursor_name or sync_mode != SyncMode.incremental:
+            logger.debug("Stream '%s': no cursor or full-refresh mode, yielding single full-scan slice", self.object_name)
             yield {}
             return
 
@@ -132,6 +134,7 @@ class GainsightCsObjectStream(GainsightCsStream):
         schema_properties = self.get_json_schema().get("properties", {})
         cursor_format = schema_properties.get(cursor_name, {}).get("format")
         if cursor_format not in ("date", "date-time"):
+            logger.debug("Stream '%s': cursor '%s' is not a date/date-time field, yielding single GTE slice", self.object_name, cursor_name)
             yield {}
             return
 
@@ -139,12 +142,14 @@ class GainsightCsObjectStream(GainsightCsStream):
 
         # First sync with no prior state: full scan, one STATE checkpoint at end
         if not start_str:
+            logger.debug("Stream '%s': no prior state for cursor '%s', yielding single full-scan slice", self.object_name, cursor_name)
             yield {}
             return
 
         try:
             start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
         except (ValueError, AttributeError):
+            logger.debug("Stream '%s': could not parse state value '%s' for cursor '%s', yielding single full-scan slice", self.object_name, start_str, cursor_name)
             yield {}
             return
 
@@ -160,6 +165,10 @@ class GainsightCsObjectStream(GainsightCsStream):
             else:
                 start_fmt = slice_start.strftime("%Y-%m-%dT%H:%M:%SZ")
                 end_fmt = slice_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+            logger.warning(
+                "Stream '%s': yielding slice %s -> %s on cursor '%s'",
+                self.object_name, start_fmt, end_fmt, cursor_name,
+            )
             yield {
                 "cursor_field": cursor_name,
                 "cursor_format": cursor_format,
@@ -176,6 +185,7 @@ class GainsightCsObjectStream(GainsightCsStream):
         stream_state: Optional[Mapping[str, Any]] = None,
         **kwargs
     ) -> Iterable[Mapping[str, Any]]:
+        logger = logging.getLogger(__name__)
         # Use configured cursor field (e.g. ["Date"]) when provided so streams can use different cursors
         if cursor_field and len(cursor_field) > 0:
             self._cursor_field_override = cursor_field[0]
@@ -183,6 +193,14 @@ class GainsightCsObjectStream(GainsightCsStream):
             self._cursor_field_override = None
         # Reset offset to 0 for each slice so pagination always starts from the beginning of the slice
         self.offset = 0
+        if stream_slice:
+            logger.warning(
+                "Stream '%s': reading slice %s -> %s (cursor: '%s', offset reset to 0)",
+                self.object_name,
+                stream_slice.get("start", "unbounded"),
+                stream_slice.get("end", "unbounded"),
+                stream_slice.get("cursor_field", "none"),
+            )
         try:
             yield from super().read_records(sync_mode, cursor_field, stream_slice, stream_state, **kwargs)
         finally:
@@ -324,7 +342,12 @@ class GainsightCsObjectStream(GainsightCsStream):
             data = body.get("data", {}).get("records", [])
             if len(data) < self.limit:
                 return None
+            prev_offset = self.offset
             self.offset = self.offset + self.limit
+            logger.debug(
+                "Stream '%s': fetched page at offset %d, advancing to %d",
+                self.object_name, prev_offset, self.offset,
+            )
             return self.offset
         except Exception as e:
             logger.error(

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -102,7 +102,17 @@ class GainsightCsObjectStream(GainsightCsStream):
         return request_body
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        records = response.json().get("data", {}).get("records", [])
+        logger = logging.getLogger(__name__)
+        try:
+            body = response.json()
+            if body.get("result") == False and body.get("errorCode") == "P_5072":
+                logger.warning(f"Skipping records for object '{self.object_name}' due to errorCode P_5072: {body.get('errorDesc', '')}")
+                return
+            records = body.get("data", {}).get("records", [])
+        except Exception as e:
+            logger.error(f"Failed to parse response for object '{self.object_name}': {e}")
+            return
+
         schema = self.get_json_schema()
         properties = schema.get("properties", {})
         

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -26,7 +26,7 @@ class GainsightCsStream(HttpStream, ABC):
 
 class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
     limit = 5000
-    SLICE_RANGE_DAYS = 30
+    SLICE_RANGE_DAYS = 1
     json_schema = None
     raise_on_http_errors = False
     # Tells the Airbyte CDK to emit an intermediate STATE message every 5,000 records.

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -226,21 +226,28 @@ class GainsightCsObjectStream(GainsightCsStream):
             yield record
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
-        # data = response.json().get("data", {}).get("records", [])
         logger = logging.getLogger(__name__)
         try:
             body = response.json()
             if body.get("result") == False:
-                logger.warning(f"Skipping next page token for object '{self.object_name}' due to error: {body.get('errorDesc', '')}")
-                return
+                logger.warning(
+                    f"Error response for object '{self.object_name}' at offset {self.offset}, "
+                    f"continuing to next page: {body.get('errorDesc', '')}"
+                )
+                self.offset = self.offset + self.limit
+                return self.offset
             data = body.get("data", {}).get("records", [])
             if len(data) < self.limit:
-                return
+                return None
             self.offset = self.offset + self.limit
             return self.offset
         except Exception as e:
-            logger.error(f"Failed to get next page token for object '{self.object_name}': {e}")
-            return
+            logger.error(
+                f"Failed to parse next page token for object '{self.object_name}' at offset {self.offset}, "
+                f"continuing to next page: {e}"
+            )
+            self.offset = self.offset + self.limit
+            return self.offset
 
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
         cursor = self._effective_cursor_field()

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -47,7 +47,9 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
         "JSON": ["null", "object"],
         "JSONBOOLEAN": ["null", "boolean"],
         "JSONNUMBER": ["null", "number"],
-        "JSONSTRING": ["null", "string"]
+        "JSONSTRING": ["null", "string"],
+        "PICKLIST": ["null", "string"],
+        "MULTISELECTDROPDOWNLIST": ["null", "string"]
     }
 
     def __init__(self, name: str, authenticator: GainsightCsAuthenticator, lookback_730_day_streams: Optional[List[str]] = None, **kwargs):
@@ -405,44 +407,44 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
             self.offset = self.offset + self.limit
             return self.offset
 
-    def get_json_schema(self) -> Mapping[str, Any]:
-        if self.json_schema is not None:
-            return self.json_schema
-
+    def _build_schema_from_describe_response(self, body: dict) -> Mapping[str, Any]:
+        """Build and cache json_schema + primary key from a /describe API response."""
         base_schema = {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "properties": {}
         }
+        if body.get('result', True):
+            fields = body.get('data', [{}])[0].get('fields', [])
+            base_schema = self.dynamic_schema(base_schema, fields)
+
+        self.json_schema = base_schema
+        if self.json_schema['properties'].get('Gsid') is not None:
+            self._primary_key = "Gsid"
+        return self.json_schema
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        if self.json_schema is not None:
+            return self.json_schema
 
         url = f"{self.url_base}meta/services/objects/{self.name}/describe?idd=true"
 
         while True:
             try:
-                session = requests.get(url, auth=self.authenticator)
-                body = session.json()
-                
-                # Check if the response indicates success
+                response = requests.get(url, auth=self.authenticator)
+                body = response.json()
+
                 if body.get('result', True):
-                    full_schema = base_schema
-                    fields = body['data'][0]['fields']
-                    full_schema = self.dynamic_schema(full_schema, fields)
-                    self.json_schema = full_schema
-                    break
+                    return self._build_schema_from_describe_response(body)
                 else:
                     # Handle rate limiting
                     if body.get('result') == False and body.get('errorCode') == 'GS_APIG_2404':
                         print("Rate limit reached. Will retry after 60 seconds...")
                         sleep(60)
                         continue
+                    return self._build_schema_from_describe_response(body)
             except requests.exceptions.RequestException:
-                self.json_schema = base_schema
-                break
-
-        # Workaround for missing gsid in many objects. Primary Key is either None or "Gsid".
-        if self.json_schema['properties'].get('Gsid') is not None:
-            self._primary_key = "Gsid"
-        return self.json_schema
+                return self._build_schema_from_describe_response({})
 
     def get_select_columns(self):
         json_schema = self.get_json_schema()

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from time import sleep, time
 import requests
 from abc import ABC
@@ -24,7 +25,8 @@ class GainsightCsStream(HttpStream, ABC):
 
 
 class GainsightCsObjectStream(GainsightCsStream):
-    limit = 500
+    limit = 5000
+    SLICE_RANGE_DAYS = 30
     json_schema = None
     raise_on_http_errors = False
 
@@ -110,6 +112,62 @@ class GainsightCsObjectStream(GainsightCsStream):
             return cf[0]
         return None
 
+    def stream_slices(
+        self,
+        sync_mode: SyncMode,
+        cursor_field: Optional[List[str]] = None,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        cursor = self.cursor_field
+        cursor_name = cursor if isinstance(cursor, str) else (cursor[0] if cursor else None)
+
+        # No cursor field or full refresh: single slice, no time bounds (existing full-scan behavior)
+        if not cursor_name or sync_mode != SyncMode.incremental:
+            yield {}
+            return
+
+        # Only apply time-window slicing to date/date-time cursor fields.
+        # Non-datetime cursors (e.g. numeric Id, string) fall back to single GTE slice.
+        schema_properties = self.get_json_schema().get("properties", {})
+        cursor_format = schema_properties.get(cursor_name, {}).get("format")
+        if cursor_format not in ("date", "date-time"):
+            yield {}
+            return
+
+        start_str = (stream_state or {}).get(cursor_name)
+
+        # First sync with no prior state: full scan, one STATE checkpoint at end
+        if not start_str:
+            yield {}
+            return
+
+        try:
+            start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            yield {}
+            return
+
+        now_dt = datetime.now(tz=timezone.utc)
+        delta = timedelta(days=self.SLICE_RANGE_DAYS)
+        slice_start = start_dt
+
+        while slice_start < now_dt:
+            slice_end = min(slice_start + delta, now_dt)
+            if cursor_format == "date":
+                start_fmt = slice_start.strftime("%Y-%m-%d")
+                end_fmt = slice_end.strftime("%Y-%m-%d")
+            else:
+                start_fmt = slice_start.strftime("%Y-%m-%dT%H:%M:%SZ")
+                end_fmt = slice_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+            yield {
+                "cursor_field": cursor_name,
+                "cursor_format": cursor_format,
+                "start": start_fmt,
+                "end": end_fmt,
+            }
+            slice_start = slice_end
+
     def read_records(
         self,
         sync_mode: SyncMode,
@@ -123,6 +181,8 @@ class GainsightCsObjectStream(GainsightCsStream):
             self._cursor_field_override = cursor_field[0]
         else:
             self._cursor_field_override = None
+        # Reset offset to 0 for each slice so pagination always starts from the beginning of the slice
+        self.offset = 0
         try:
             yield from super().read_records(sync_mode, cursor_field, stream_slice, stream_state, **kwargs)
         finally:
@@ -177,23 +237,48 @@ class GainsightCsObjectStream(GainsightCsStream):
         body = {
             "select": select_columns,
             "limit": self.limit,
-            "offset": offset
+            "offset": offset,
         }
-        cursor_field_name = self._effective_cursor_field()
-        cursor_value = (stream_state or {}).get(cursor_field_name) if cursor_field_name else None
-        if cursor_value and cursor_field_name:
-            schema_properties = self.get_json_schema().get("properties", {})
+
+        slice_start = (stream_slice or {}).get("start")
+        slice_end = (stream_slice or {}).get("end")
+        slice_cursor = (stream_slice or {}).get("cursor_field")
+        cursor_field_name = slice_cursor or self._effective_cursor_field()
+        schema_properties = self.get_json_schema().get("properties", {})
+
+        if slice_start and slice_end and cursor_field_name:
+            # Time-window slice: bounded GTE + LT filter with orderBy for deterministic offset pagination
             if cursor_field_name in schema_properties:
                 body["where"] = {
-                    "conditions": [{"name": cursor_field_name, "alias": "A", "value": [cursor_value], "operator": "GTE"}],
-                    "expression": "A"
+                    "conditions": [
+                        {"name": cursor_field_name, "alias": "A", "value": [slice_start], "operator": "GTE"},
+                        {"name": cursor_field_name, "alias": "B", "value": [slice_end], "operator": "LT"},
+                    ],
+                    "expression": "A AND B",
                 }
+                body["orderBy"] = {cursor_field_name: "asc"}
             else:
                 logger.warning(
                     "Cursor field '%s' not present on object '%s'; skipping incremental filter to avoid API error. Sync will read all records.",
                     cursor_field_name,
                     self.object_name,
                 )
+        elif cursor_field_name:
+            # Single-slice fallback: open-ended GTE filter for non-datetime cursors or first sync
+            cursor_value = (stream_state or {}).get(cursor_field_name)
+            if cursor_value:
+                if cursor_field_name in schema_properties:
+                    body["where"] = {
+                        "conditions": [{"name": cursor_field_name, "alias": "A", "value": [cursor_value], "operator": "GTE"}],
+                        "expression": "A",
+                    }
+                else:
+                    logger.warning(
+                        "Cursor field '%s' not present on object '%s'; skipping incremental filter to avoid API error. Sync will read all records.",
+                        cursor_field_name,
+                        self.object_name,
+                    )
+
         return body
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -171,6 +171,8 @@ class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
         else:
             try:
                 start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+                if start_dt.tzinfo is None:
+                    start_dt = start_dt.replace(tzinfo=timezone.utc)
             except (ValueError, AttributeError):
                 self.logger.info(
                     "Stream '%s': could not parse state for cursor '%s' (value: %s), yielding single full-scan slice",

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -1,7 +1,9 @@
 from time import sleep, time
 import requests
 from abc import ABC
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Union
+from airbyte_cdk.models import AirbyteStream, SyncMode
+from airbyte_cdk.sources.streams.core import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 import logging
 
@@ -24,7 +26,6 @@ class GainsightCsStream(HttpStream, ABC):
 class GainsightCsObjectStream(GainsightCsStream):
     limit = 500
     json_schema = None
-    offset = 0
     raise_on_http_errors = False
 
     gainsight_airbyte_type_map = {
@@ -49,6 +50,83 @@ class GainsightCsObjectStream(GainsightCsStream):
         super().__init__(authenticator, **kwargs)
         self.object_name = name
         self._primary_key = None
+        self.offset = 0
+        self._cursor_field_override: Optional[str] = None
+
+    @property
+    def cursor_field(self) -> Union[str, List[str]]:
+        """Default cursor is ModifiedDate only if present in this stream's schema; else no cursor (full refresh only)."""
+        schema_properties = self.get_json_schema().get("properties", {})
+        if "ModifiedDate" in schema_properties:
+            return "ModifiedDate"
+        return []
+
+    @property
+    def source_defined_cursor(self) -> bool:
+        """Cursor is source-defined only when ModifiedDate exists in the schema; otherwise users pick their own cursor."""
+        schema_properties = self.get_json_schema().get("properties", {})
+        return "ModifiedDate" in schema_properties
+
+    def as_airbyte_stream(self) -> AirbyteStream:
+        """Always expose both full_refresh and incremental sync modes.
+
+        When ModifiedDate is present: source-defined cursor defaulting to ModifiedDate.
+        When ModifiedDate is absent: no default cursor so the UI defaults to Full Refresh | Append,
+        but incremental is still offered so the user can select any cursor field.
+        """
+        schema = self.get_json_schema()
+        schema_properties = schema.get("properties", {})
+        has_modified_date = "ModifiedDate" in schema_properties
+
+        stream = AirbyteStream(
+            name=self.name,
+            json_schema=dict(schema),
+            supported_sync_modes=[SyncMode.full_refresh, SyncMode.incremental],
+        )
+
+        if self.namespace:
+            stream.namespace = self.namespace
+
+        if has_modified_date:
+            stream.source_defined_cursor = True
+            stream.default_cursor_field = ["ModifiedDate"]
+        else:
+            stream.source_defined_cursor = False
+
+        keys = Stream._wrapped_primary_key(self.primary_key)
+        if keys and len(keys) > 0:
+            stream.source_defined_primary_key = keys
+
+        return stream
+
+    def _effective_cursor_field(self) -> Optional[str]:
+        """Use configured cursor field from read_records when set, else stream default. None if stream has no cursor."""
+        if self._cursor_field_override is not None:
+            return self._cursor_field_override
+        cf = self.cursor_field
+        if isinstance(cf, str):
+            return cf
+        if isinstance(cf, list) and len(cf) > 0:
+            return cf[0]
+        return None
+
+    def read_records(
+        self,
+        sync_mode: SyncMode,
+        cursor_field: Optional[List[str]] = None,
+        stream_slice: Optional[Mapping[str, Any]] = None,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs
+    ) -> Iterable[Mapping[str, Any]]:
+        # Use configured cursor field (e.g. ["Date"]) when provided so streams can use different cursors
+        if cursor_field and len(cursor_field) > 0:
+            self._cursor_field_override = cursor_field[0]
+        else:
+            self._cursor_field_override = None
+        try:
+            yield from super().read_records(sync_mode, cursor_field, stream_slice, stream_state, **kwargs)
+        finally:
+            self._cursor_field_override = None
 
     @property
     def name(self):
@@ -93,14 +171,30 @@ class GainsightCsObjectStream(GainsightCsStream):
         return "POST"
 
     def request_body_json(self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None) -> Optional[Union[Dict[str, Any], str]]:
+        logger = logging.getLogger(__name__)
         select_columns = self.get_select_columns()
         offset = self.offset if next_page_token is None else next_page_token
-        request_body = {
-          "select": select_columns,
-          "limit": self.limit,
-          "offset": offset
+        body = {
+            "select": select_columns,
+            "limit": self.limit,
+            "offset": offset
         }
-        return request_body
+        cursor_field_name = self._effective_cursor_field()
+        cursor_value = (stream_state or {}).get(cursor_field_name) if cursor_field_name else None
+        if cursor_value and cursor_field_name:
+            schema_properties = self.get_json_schema().get("properties", {})
+            if cursor_field_name in schema_properties:
+                body["where"] = {
+                    "conditions": [{"name": cursor_field_name, "alias": "A", "value": [cursor_value], "operator": "GTE"}],
+                    "expression": "A"
+                }
+            else:
+                logger.warning(
+                    "Cursor field '%s' not present on object '%s'; skipping incremental filter to avoid API error. Sync will read all records.",
+                    cursor_field_name,
+                    self.object_name,
+                )
+        return body
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         logger = logging.getLogger(__name__)
@@ -147,6 +241,14 @@ class GainsightCsObjectStream(GainsightCsStream):
         except Exception as e:
             logger.error(f"Failed to get next page token for object '{self.object_name}': {e}")
             return
+
+    def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
+        cursor = self._effective_cursor_field()
+        if cursor is None:
+            return dict(current_stream_state) if current_stream_state else {}
+        latest_cursor = latest_record.get(cursor) or ""
+        current_cursor = current_stream_state.get(cursor, "")
+        return {cursor: max(current_cursor, latest_cursor)}
 
     def get_json_schema(self) -> Mapping[str, Any]:
         if self.json_schema is not None:

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -29,6 +29,8 @@ class GainsightCsObjectStream(GainsightCsStream):
     SLICE_RANGE_DAYS = 30
     json_schema = None
     raise_on_http_errors = False
+    # Tells the Airbyte CDK to emit an intermediate STATE message every 5,000 records.
+    state_checkpoint_interval = 5000
 
     gainsight_airbyte_type_map = {
         "STRING": ["null", "string"],
@@ -54,6 +56,7 @@ class GainsightCsObjectStream(GainsightCsStream):
         self._primary_key = None
         self.offset = 0
         self._cursor_field_override: Optional[str] = None
+        self._current_slice: Optional[Mapping[str, Any]] = None
 
     @property
     def cursor_field(self) -> Union[str, List[str]]:
@@ -193,6 +196,7 @@ class GainsightCsObjectStream(GainsightCsStream):
             self._cursor_field_override = None
         # Reset offset to 0 for each slice so pagination always starts from the beginning of the slice
         self.offset = 0
+        self._current_slice = stream_slice
         if stream_slice:
             logger.warning(
                 "Stream '%s': reading slice %s -> %s (cursor: '%s', offset reset to 0)",
@@ -205,6 +209,7 @@ class GainsightCsObjectStream(GainsightCsStream):
             yield from super().read_records(sync_mode, cursor_field, stream_slice, stream_state, **kwargs)
         finally:
             self._cursor_field_override = None
+            self._current_slice = None
 
     @property
     def name(self):
@@ -363,7 +368,10 @@ class GainsightCsObjectStream(GainsightCsStream):
             return dict(current_stream_state) if current_stream_state else {}
         latest_cursor = latest_record.get(cursor) or ""
         current_cursor = current_stream_state.get(cursor, "")
-        return {cursor: max(current_cursor, latest_cursor)}
+        # Also consider the slice end so state advances forward even when records
+        # have an older cursor value (e.g. during the final page of a time-window slice)
+        slice_end = (self._current_slice or {}).get("end", "")
+        return {cursor: max(current_cursor, latest_cursor, slice_end)}
 
     def get_json_schema(self) -> Mapping[str, Any]:
         if self.json_schema is not None:

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -4,7 +4,7 @@ import requests
 from abc import ABC
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Union
 from airbyte_cdk.models import AirbyteStream, SyncMode
-from airbyte_cdk.sources.streams.core import Stream
+from airbyte_cdk.sources.streams.core import CheckpointMixin, Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 import logging
 
@@ -24,7 +24,7 @@ class GainsightCsStream(HttpStream, ABC):
         return f"{self._authenticator.domain_url}/v1/"
 
 
-class GainsightCsObjectStream(GainsightCsStream):
+class GainsightCsObjectStream(GainsightCsStream, CheckpointMixin):
     limit = 5000
     SLICE_RANGE_DAYS = 30
     json_schema = None
@@ -74,52 +74,32 @@ class GainsightCsObjectStream(GainsightCsStream):
         else:
             self._state = {}
 
-    @property
-    def supports_incremental(self) -> bool:
-        """All streams support incremental; the actual cursor is set by the catalog (cursor_field arg).
-        Without this override, streams without ModifiedDate return cursor_field=[] which makes the
-        installed CDK treat them as full refresh and never call _read_incremental."""
-        return True
-
-    @property
-    def cursor_field(self) -> Union[str, List[str]]:
-        """Default cursor is ModifiedDate only if present in this stream's schema; else no cursor (full refresh only)."""
-        schema_properties = self.get_json_schema().get("properties", {})
-        if "ModifiedDate" in schema_properties:
-            return "ModifiedDate"
-        return []
-
-    @property
-    def source_defined_cursor(self) -> bool:
-        """Cursor is source-defined only when ModifiedDate exists in the schema; otherwise users pick their own cursor."""
-        schema_properties = self.get_json_schema().get("properties", {})
-        return "ModifiedDate" in schema_properties
+    def _get_checkpoint_reader(self, logger, cursor_field, sync_mode, stream_state):
+        """Override to set _cursor_field_override from the catalog cursor_field *before*
+        _checkpoint_mode is evaluated. Without this, cursor_field returns [] and CDK 0.90
+        routes the stream to RESUMABLE_FULL_REFRESH, which re-calls stream_slices with
+        updated state after every STATE emission — causing an infinite sync loop."""
+        if cursor_field and len(cursor_field) > 0:
+            self._cursor_field_override = cursor_field[0]
+        else:
+            self._cursor_field_override = None
+        return super()._get_checkpoint_reader(
+            logger=logger, cursor_field=cursor_field, sync_mode=sync_mode, stream_state=stream_state
+        )
 
     def as_airbyte_stream(self) -> AirbyteStream:
-        """Always expose both full_refresh and incremental sync modes.
-
-        When ModifiedDate is present: source-defined cursor defaulting to ModifiedDate.
-        When ModifiedDate is absent: no default cursor so the UI defaults to Full Refresh | Append,
-        but incremental is still offered so the user can select any cursor field.
+        """Expose both full_refresh and incremental sync modes with no source-defined cursor.
+        The user selects a cursor field in the catalog for any stream they want to sync incrementally.
         """
-        schema = self.get_json_schema()
-        schema_properties = schema.get("properties", {})
-        has_modified_date = "ModifiedDate" in schema_properties
-
         stream = AirbyteStream(
             name=self.name,
-            json_schema=dict(schema),
+            json_schema=dict(self.get_json_schema()),
             supported_sync_modes=[SyncMode.full_refresh, SyncMode.incremental],
+            source_defined_cursor=False,
         )
 
         if self.namespace:
             stream.namespace = self.namespace
-
-        if has_modified_date:
-            stream.source_defined_cursor = True
-            stream.default_cursor_field = ["ModifiedDate"]
-        else:
-            stream.source_defined_cursor = False
 
         keys = Stream._wrapped_primary_key(self.primary_key)
         if keys and len(keys) > 0:
@@ -127,16 +107,16 @@ class GainsightCsObjectStream(GainsightCsStream):
 
         return stream
 
-    def _effective_cursor_field(self) -> Optional[str]:
-        """Use configured cursor field from read_records when set, else stream default. None if stream has no cursor."""
-        if self._cursor_field_override is not None:
+    @property
+    def cursor_field(self) -> Union[str, List[str]]:
+        """Return the catalog-configured cursor field so CDK routes to INCREMENTAL (not RESUMABLE_FULL_REFRESH)."""
+        if self._cursor_field_override:
             return self._cursor_field_override
-        cf = self.cursor_field
-        if isinstance(cf, str):
-            return cf
-        if isinstance(cf, list) and len(cf) > 0:
-            return cf[0]
-        return None
+        return []
+
+    def _effective_cursor_field(self) -> Optional[str]:
+        """Returns the catalog-configured cursor field when set by read_records, else None."""
+        return self._cursor_field_override
 
     def stream_slices(
         self,
@@ -145,12 +125,11 @@ class GainsightCsObjectStream(GainsightCsStream):
         stream_state: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ) -> Iterable[Optional[Mapping[str, Any]]]:
-        # Use catalog-configured cursor when provided (incremental with custom cursor); else stream default
+        # Use catalog-configured cursor when provided (incremental with custom cursor); else no cursor
         if cursor_field and len(cursor_field) > 0:
             cursor_name = cursor_field[0]
         else:
-            cursor = self.cursor_field
-            cursor_name = cursor if isinstance(cursor, str) else (cursor[0] if cursor else None)
+            cursor_name = None
 
         # No cursor field or full refresh: single slice, no time bounds (existing full-scan behavior)
         if not cursor_name or sync_mode != SyncMode.incremental:
@@ -243,11 +222,9 @@ class GainsightCsObjectStream(GainsightCsStream):
             yield from super().read_records(sync_mode, cursor_field, stream_slice, stream_state, **kwargs)
         finally:
             # Advance self._state to at least the slice end so empty slices still move state forward.
-            # _checkpoint_state reads stream.state directly, so we must keep it up to date here.
-            cursor = self._cursor_field_override or (
-                self.cursor_field if isinstance(self.cursor_field, str)
-                else (self.cursor_field[0] if self.cursor_field else None)
-            )
+            # CDK 0.90 reads stream.state via _observe_state() after each slice, so this ensures
+            # slices with no records still advance the checkpoint rather than stalling.
+            cursor = self._cursor_field_override
             slice_end = (self._current_slice or {}).get("end", "")
             if cursor and slice_end:
                 current = self._state.get(cursor, "")
@@ -371,11 +348,19 @@ class GainsightCsObjectStream(GainsightCsStream):
             if field_schema.get("format") in ["date", "date-time"]
         ]
         
-        # Transform empty strings to null for date/datetime fields
+        # Transform empty strings to null for date/datetime fields, and advance self._state
+        # per record so CDK 0.90's _observe_state() reads the correct cursor value for each
+        # mid-stream STATE checkpoint (state_checkpoint_interval) and for the final checkpoint.
+        cursor = self._effective_cursor_field()
         for record in records:
             for field_name in date_fields:
                 if field_name in record and record[field_name] == "":
                     record[field_name] = None
+            if cursor and record.get(cursor):
+                current = self._state.get(cursor, "")
+                new_val = record[cursor]
+                if new_val > current:
+                    self._state = {cursor: new_val}
             yield record
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
@@ -406,20 +391,6 @@ class GainsightCsObjectStream(GainsightCsStream):
             )
             self.offset = self.offset + self.limit
             return self.offset
-
-    def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
-        cursor = self._effective_cursor_field()
-        if cursor is None:
-            return dict(current_stream_state) if current_stream_state else {}
-        latest_cursor = latest_record.get(cursor) or ""
-        current_cursor = current_stream_state.get(cursor, "")
-        # Also consider the slice end so state advances forward even when records
-        # have an older cursor value (e.g. during the final page of a time-window slice)
-        slice_end = (self._current_slice or {}).get("end", "")
-        new_state = {cursor: max(current_cursor, latest_cursor, slice_end)}
-        # Keep self._state current so _checkpoint_state (which reads stream.state) gets the latest value
-        self._state = new_state
-        return new_state
 
     def get_json_schema(self) -> Mapping[str, Any]:
         if self.json_schema is not None:

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -57,6 +57,29 @@ class GainsightCsObjectStream(GainsightCsStream):
         self.offset = 0
         self._cursor_field_override: Optional[str] = None
         self._current_slice: Optional[Mapping[str, Any]] = None
+        self._state: MutableMapping[str, Any] = {}
+
+    @property
+    def state(self) -> MutableMapping[str, Any]:
+        """State getter so AbstractSource can set state before read(); CDK then uses this in Stream.read()."""
+        return self._state
+
+    @state.setter
+    def state(self, value: MutableMapping[str, Any]) -> None:
+        """State setter so incoming stream state from the state file is stored and passed to stream_slices."""
+        if value is None:
+            self._state = {}
+        elif isinstance(value, dict):
+            self._state = dict(value)
+        else:
+            self._state = {}
+
+    @property
+    def supports_incremental(self) -> bool:
+        """All streams support incremental; the actual cursor is set by the catalog (cursor_field arg).
+        Without this override, streams without ModifiedDate return cursor_field=[] which makes the
+        installed CDK treat them as full refresh and never call _read_incremental."""
+        return True
 
     @property
     def cursor_field(self) -> Union[str, List[str]]:
@@ -122,13 +145,16 @@ class GainsightCsObjectStream(GainsightCsStream):
         stream_state: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ) -> Iterable[Optional[Mapping[str, Any]]]:
-        logger = logging.getLogger(__name__)
-        cursor = self.cursor_field
-        cursor_name = cursor if isinstance(cursor, str) else (cursor[0] if cursor else None)
+        # Use catalog-configured cursor when provided (incremental with custom cursor); else stream default
+        if cursor_field and len(cursor_field) > 0:
+            cursor_name = cursor_field[0]
+        else:
+            cursor = self.cursor_field
+            cursor_name = cursor if isinstance(cursor, str) else (cursor[0] if cursor else None)
 
         # No cursor field or full refresh: single slice, no time bounds (existing full-scan behavior)
         if not cursor_name or sync_mode != SyncMode.incremental:
-            logger.debug("Stream '%s': no cursor or full-refresh mode, yielding single full-scan slice", self.object_name)
+            self.logger.debug("Stream '%s': no cursor or full-refresh mode, yielding single full-scan slice", self.object_name)
             yield {}
             return
 
@@ -137,7 +163,10 @@ class GainsightCsObjectStream(GainsightCsStream):
         schema_properties = self.get_json_schema().get("properties", {})
         cursor_format = schema_properties.get(cursor_name, {}).get("format")
         if cursor_format not in ("date", "date-time"):
-            logger.debug("Stream '%s': cursor '%s' is not a date/date-time field, yielding single GTE slice", self.object_name, cursor_name)
+            self.logger.info(
+                "Stream '%s': cursor '%s' is not a date/date-time field, yielding single GTE slice",
+                self.object_name, cursor_name,
+            )
             yield {}
             return
 
@@ -145,14 +174,20 @@ class GainsightCsObjectStream(GainsightCsStream):
 
         # First sync with no prior state: full scan, one STATE checkpoint at end
         if not start_str:
-            logger.debug("Stream '%s': no prior state for cursor '%s', yielding single full-scan slice", self.object_name, cursor_name)
+            self.logger.info(
+                "Stream '%s': incremental with cursor '%s', no prior state — full scan (single slice)",
+                self.object_name, cursor_name,
+            )
             yield {}
             return
 
         try:
             start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
         except (ValueError, AttributeError):
-            logger.debug("Stream '%s': could not parse state value '%s' for cursor '%s', yielding single full-scan slice", self.object_name, start_str, cursor_name)
+            self.logger.info(
+                "Stream '%s': could not parse state for cursor '%s' (value: %s), yielding single full-scan slice",
+                self.object_name, cursor_name, start_str,
+            )
             yield {}
             return
 
@@ -168,7 +203,7 @@ class GainsightCsObjectStream(GainsightCsStream):
             else:
                 start_fmt = slice_start.strftime("%Y-%m-%dT%H:%M:%SZ")
                 end_fmt = slice_end.strftime("%Y-%m-%dT%H:%M:%SZ")
-            logger.warning(
+            self.logger.info(
                 "Stream '%s': yielding slice %s -> %s on cursor '%s'",
                 self.object_name, start_fmt, end_fmt, cursor_name,
             )
@@ -188,7 +223,6 @@ class GainsightCsObjectStream(GainsightCsStream):
         stream_state: Optional[Mapping[str, Any]] = None,
         **kwargs
     ) -> Iterable[Mapping[str, Any]]:
-        logger = logging.getLogger(__name__)
         # Use configured cursor field (e.g. ["Date"]) when provided so streams can use different cursors
         if cursor_field and len(cursor_field) > 0:
             self._cursor_field_override = cursor_field[0]
@@ -198,7 +232,7 @@ class GainsightCsObjectStream(GainsightCsStream):
         self.offset = 0
         self._current_slice = stream_slice
         if stream_slice:
-            logger.warning(
+            self.logger.info(
                 "Stream '%s': reading slice %s -> %s (cursor: '%s', offset reset to 0)",
                 self.object_name,
                 stream_slice.get("start", "unbounded"),
@@ -208,6 +242,17 @@ class GainsightCsObjectStream(GainsightCsStream):
         try:
             yield from super().read_records(sync_mode, cursor_field, stream_slice, stream_state, **kwargs)
         finally:
+            # Advance self._state to at least the slice end so empty slices still move state forward.
+            # _checkpoint_state reads stream.state directly, so we must keep it up to date here.
+            cursor = self._cursor_field_override or (
+                self.cursor_field if isinstance(self.cursor_field, str)
+                else (self.cursor_field[0] if self.cursor_field else None)
+            )
+            slice_end = (self._current_slice or {}).get("end", "")
+            if cursor and slice_end:
+                current = self._state.get(cursor, "")
+                if slice_end > current:
+                    self._state = {cursor: slice_end}
             self._cursor_field_override = None
             self._current_slice = None
 
@@ -371,7 +416,10 @@ class GainsightCsObjectStream(GainsightCsStream):
         # Also consider the slice end so state advances forward even when records
         # have an older cursor value (e.g. during the final page of a time-window slice)
         slice_end = (self._current_slice or {}).get("end", "")
-        return {cursor: max(current_cursor, latest_cursor, slice_end)}
+        new_state = {cursor: max(current_cursor, latest_cursor, slice_end)}
+        # Keep self._state current so _checkpoint_state (which reads stream.state) gets the latest value
+        self._state = new_state
+        return new_state
 
     def get_json_schema(self) -> Mapping[str, Any]:
         if self.json_schema is not None:

--- a/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/source_gainsight_cs/streams.py
@@ -25,6 +25,7 @@ class GainsightCsObjectStream(GainsightCsStream):
     limit = 500
     json_schema = None
     offset = 0
+    raise_on_http_errors = False
 
     gainsight_airbyte_type_map = {
         "STRING": ["null", "string"],
@@ -105,8 +106,8 @@ class GainsightCsObjectStream(GainsightCsStream):
         logger = logging.getLogger(__name__)
         try:
             body = response.json()
-            if body.get("result") == False and body.get("errorCode") == "P_5072":
-                logger.warning(f"Skipping records for object '{self.object_name}' due to errorCode P_5072: {body.get('errorDesc', '')}")
+            if body.get("result") == False:
+                logger.warning(f"Skipping records for object '{self.object_name}' due to error: {body.get('errorDesc', '')}")
                 return
             records = body.get("data", {}).get("records", [])
         except Exception as e:
@@ -131,11 +132,21 @@ class GainsightCsObjectStream(GainsightCsStream):
             yield record
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
-        data = response.json().get("data", {}).get("records", [])
-        if len(data) < self.limit:
-            return None
-        self.offset = self.offset + self.limit
-        return self.offset
+        # data = response.json().get("data", {}).get("records", [])
+        logger = logging.getLogger(__name__)
+        try:
+            body = response.json()
+            if body.get("result") == False:
+                logger.warning(f"Skipping next page token for object '{self.object_name}' due to error: {body.get('errorDesc', '')}")
+                return
+            data = body.get("data", {}).get("records", [])
+            if len(data) < self.limit:
+                return
+            self.offset = self.offset + self.limit
+            return self.offset
+        except Exception as e:
+            logger.error(f"Failed to get next page token for object '{self.object_name}': {e}")
+            return
 
     def get_json_schema(self) -> Mapping[str, Any]:
         if self.json_schema is not None:

--- a/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_source.py
@@ -10,13 +10,19 @@ from source_gainsight_cs.source import SourceGainsightCs, GainsightCsAuthenticat
 
 
 GAINSIGHT_DOMAIN_URL = "https://fake-domain.gainsightcloud.com"
-FAKE_TOKEN = 'ABC123'
+FAKE_CLIENT_ID = "my-client-id"
+FAKE_CLIENT_SECRET = "my-client-secret"
+FAKE_ACCESS_TOKEN = "fake-access-token"
 GAINSIGHT_OBJECTS = ["person", "playbook", "gsuer", "company", "custom1", "custom2"]
 
 
 @pytest.fixture(name="config")
 def config_fixture():
-    return {"access_key": FAKE_TOKEN, "domain_url": GAINSIGHT_DOMAIN_URL}
+    return {
+        "client_id": FAKE_CLIENT_ID,
+        "client_secret": FAKE_CLIENT_SECRET,
+        "domain_url": GAINSIGHT_DOMAIN_URL,
+    }
 
 
 @pytest.fixture
@@ -24,25 +30,27 @@ def mock_get_objects(mocker):
     mocker.patch.object(SourceGainsightCs, "get_objects", return_value=GAINSIGHT_OBJECTS)
 
 
-def test_gainsight_cs_authenticator():
-    authenticator = GainsightCsAuthenticator(FAKE_TOKEN)
-    assert authenticator.get_auth_header() == {"AccessKey": FAKE_TOKEN}
-
-
-def test_get_authenticator(config):
-    auth = SourceGainsightCs._get_authenticator(config)
-    assert auth._token == GainsightCsAuthenticator(FAKE_TOKEN)._token
+def test_gainsight_cs_authenticator(config):
+    authenticator = GainsightCsAuthenticator(config)
+    assert authenticator._client_id == FAKE_CLIENT_ID
+    assert authenticator._client_secret == FAKE_CLIENT_SECRET
+    assert authenticator.domain_url == GAINSIGHT_DOMAIN_URL
 
 
 @responses.activate
 def test_check_connection(config):
-    source = SourceGainsightCs()
-    logger_mock = MagicMock()
+    responses.add(
+        responses.POST,
+        f"{GAINSIGHT_DOMAIN_URL}/v1/users/m2m/oauth/token",
+        json={"access_token": FAKE_ACCESS_TOKEN, "expires_in": 3600},
+    )
     responses.add(
         responses.GET,
         f"{GAINSIGHT_DOMAIN_URL}/v1/meta/services/objects/Person/describe?idd=true",
         json=[],
     )
+    source = SourceGainsightCs()
+    logger_mock = MagicMock()
     ok, error_msg = source.check_connection(logger_mock, config)
 
     assert ok

--- a/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
@@ -228,3 +228,78 @@ def test_source_defined_cursor_false_when_modified_date_absent(patch_base_class,
     stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "Name": {}}})
     assert stream.source_defined_cursor is False
+
+
+def test_state_checkpoint_interval_is_set(patch_base_class, mock_authenticator):
+    """state_checkpoint_interval must be set so the CDK emits STATE messages mid-stream
+    for large streams like activity_timeline that would otherwise never checkpoint."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    assert stream.state_checkpoint_interval is not None
+    assert stream.state_checkpoint_interval > 0
+
+
+def test_get_updated_state_advances_to_slice_end_when_records_are_older(patch_base_class, mock_authenticator, mocker):
+    """When a time-window slice completes, state must advance to slice end even if all
+    records have an earlier ModifiedDate — preventing the same window from re-syncing."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
+    stream._current_slice = {
+        "cursor_field": "ModifiedDate",
+        "start": "2026-03-01T00:00:00Z",
+        "end": "2026-03-10T21:08:06Z",
+    }
+    current_state = {"ModifiedDate": "2026-03-01T00:00:00Z"}
+    # Record's ModifiedDate is older than slice end
+    latest_record = {"Gsid": "abc", "ModifiedDate": "2026-03-05T12:00:00Z"}
+    new_state = stream.get_updated_state(current_state, latest_record)
+    assert new_state == {"ModifiedDate": "2026-03-10T21:08:06Z"}
+
+
+def test_get_updated_state_uses_record_when_newer_than_slice_end(patch_base_class, mock_authenticator, mocker):
+    """If a record's cursor value is somehow newer than the slice end, the record value wins."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
+    stream._current_slice = {
+        "cursor_field": "ModifiedDate",
+        "start": "2026-03-01T00:00:00Z",
+        "end": "2026-03-05T00:00:00Z",
+    }
+    current_state = {"ModifiedDate": "2026-03-01T00:00:00Z"}
+    latest_record = {"Gsid": "abc", "ModifiedDate": "2026-03-09T00:04:30Z"}
+    new_state = stream.get_updated_state(current_state, latest_record)
+    assert new_state == {"ModifiedDate": "2026-03-09T00:04:30Z"}
+
+
+def test_get_updated_state_no_slice_still_advances_from_record(patch_base_class, mock_authenticator, mocker):
+    """Full-scan syncs (no active slice) still advance state from the latest record."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
+    stream._current_slice = None
+    current_state = {"ModifiedDate": "2026-03-01T00:00:00Z"}
+    latest_record = {"Gsid": "abc", "ModifiedDate": "2026-03-10T21:08:06Z"}
+    new_state = stream.get_updated_state(current_state, latest_record)
+    assert new_state == {"ModifiedDate": "2026-03-10T21:08:06Z"}
+
+
+def test_read_records_sets_and_clears_current_slice(patch_base_class, mock_authenticator, mocker):
+    """_current_slice must be set during read_records and cleared afterwards,
+    so get_updated_state has access to the slice boundaries during the read."""
+    from airbyte_cdk.models import SyncMode
+
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
+
+    captured_slice_during_read = {}
+    original_super_read = lambda *a, **kw: iter([{"ModifiedDate": "2026-03-05T00:00:00Z"}])
+
+    def fake_super_read(*args, **kwargs):
+        captured_slice_during_read["slice"] = stream._current_slice
+        return iter([{"ModifiedDate": "2026-03-05T00:00:00Z"}])
+
+    mocker.patch("airbyte_cdk.sources.streams.http.HttpStream.read_records", side_effect=fake_super_read)
+
+    test_slice = {"cursor_field": "ModifiedDate", "start": "2026-03-01T00:00:00Z", "end": "2026-03-10T21:08:06Z"}
+    list(stream.read_records(SyncMode.incremental, stream_slice=test_slice))
+
+    assert captured_slice_during_read["slice"] == test_slice
+    assert stream._current_slice is None

--- a/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
@@ -61,6 +61,24 @@ def test_next_page_token_end(patch_base_class, mock_authenticator):
     assert stream.next_page_token(**inputs) == expected_token
 
 
+def test_next_page_token_error_response_returns_none(patch_base_class, mock_authenticator):
+    """An API error response (result=False) skips past the errored page by advancing the offset."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    response = MagicMock()
+    response.json.return_value = {"result": False, "errorDesc": "Some API error"}
+    expected_token = stream.offset + stream.limit
+    assert stream.next_page_token(response=response) == expected_token
+
+
+def test_next_page_token_exception_returns_none(patch_base_class, mock_authenticator):
+    """A response that cannot be parsed advances the offset to skip past the problematic page."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    response = MagicMock()
+    response.json.side_effect = Exception("malformed JSON")
+    expected_token = stream.offset + stream.limit
+    assert stream.next_page_token(response=response) == expected_token
+
+
 def test_parse_response(patch_base_class, mock_authenticator, mocker):
     stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"test_id": {}}})
@@ -153,37 +171,9 @@ def test_request_body_json_state_but_cursor_not_in_schema_no_where(patch_base_cl
     assert "where" not in body
 
 
-def test_get_updated_state_advances_cursor(patch_base_class, mock_authenticator, mocker):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
-    current_state = {"ModifiedDate": "2024-01-01T00:00:00Z"}
-    latest_record = {"Gsid": "abc", "ModifiedDate": "2024-02-01T12:00:00Z"}
-    new_state = stream.get_updated_state(current_state, latest_record)
-    assert new_state == {"ModifiedDate": "2024-02-01T12:00:00Z"}
-    assert stream.state == {"ModifiedDate": "2024-02-01T12:00:00Z"}
-
-
-def test_get_updated_state_keeps_cursor_when_record_older(patch_base_class, mock_authenticator, mocker):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
-    current_state = {"ModifiedDate": "2024-02-01T12:00:00Z"}
-    latest_record = {"Gsid": "abc", "ModifiedDate": "2024-01-01T00:00:00Z"}
-    new_state = stream.get_updated_state(current_state, latest_record)
-    assert new_state == {"ModifiedDate": "2024-02-01T12:00:00Z"}
-
-
-def test_get_updated_state_no_cursor_returns_current_state(patch_base_class, mock_authenticator, mocker):
-    """When stream has no cursor field (e.g. ModifiedDate not in schema), state is unchanged."""
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "Name": {}}})
-    current_state = {"other_key": "value"}
-    latest_record = {"Gsid": "abc", "Name": "foo"}
-    new_state = stream.get_updated_state(current_state, latest_record)
-    assert new_state == {"other_key": "value"}
-
-
-def test_as_airbyte_stream_with_modified_date(patch_base_class, mock_authenticator, mocker):
-    """Streams with ModifiedDate should advertise both sync modes, source-defined cursor, and ModifiedDate as default cursor field."""
+def test_as_airbyte_stream(patch_base_class, mock_authenticator, mocker):
+    """All streams advertise both sync modes with no source-defined cursor.
+    The catalog always supplies the cursor field for incremental syncs."""
     stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     mocker.patch.object(
         stream,
@@ -195,40 +185,8 @@ def test_as_airbyte_stream_with_modified_date(patch_base_class, mock_authenticat
     from airbyte_cdk.models import SyncMode as SM
     assert SM.full_refresh in airbyte_stream.supported_sync_modes
     assert SM.incremental in airbyte_stream.supported_sync_modes
-    assert airbyte_stream.source_defined_cursor is True
-    assert airbyte_stream.default_cursor_field == ["ModifiedDate"]
-
-
-def test_as_airbyte_stream_without_modified_date(patch_base_class, mock_authenticator, mocker):
-    """Streams without ModifiedDate should still advertise both sync modes, but with no source-defined cursor and no default cursor field,
-    so the UI defaults to Full Refresh | Append while still allowing Incremental | Append with a user-chosen cursor."""
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(
-        stream,
-        "get_json_schema",
-        return_value={"properties": {"Gsid": {}, "Date": {"type": ["null", "string"], "format": "date"}}},
-    )
-    airbyte_stream = stream.as_airbyte_stream()
-
-    from airbyte_cdk.models import SyncMode as SM
-    assert SM.full_refresh in airbyte_stream.supported_sync_modes
-    assert SM.incremental in airbyte_stream.supported_sync_modes
     assert airbyte_stream.source_defined_cursor is False
     assert not airbyte_stream.default_cursor_field
-
-
-def test_source_defined_cursor_true_when_modified_date_present(patch_base_class, mock_authenticator, mocker):
-    """source_defined_cursor should be True when ModifiedDate is in the stream schema."""
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "ModifiedDate": {}}})
-    assert stream.source_defined_cursor is True
-
-
-def test_source_defined_cursor_false_when_modified_date_absent(patch_base_class, mock_authenticator, mocker):
-    """source_defined_cursor should be False when ModifiedDate is not in the stream schema."""
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "Name": {}}})
-    assert stream.source_defined_cursor is False
 
 
 def test_state_checkpoint_interval_is_set(patch_base_class, mock_authenticator):
@@ -239,52 +197,9 @@ def test_state_checkpoint_interval_is_set(patch_base_class, mock_authenticator):
     assert stream.state_checkpoint_interval > 0
 
 
-def test_get_updated_state_advances_to_slice_end_when_records_are_older(patch_base_class, mock_authenticator, mocker):
-    """When a time-window slice completes, state must advance to slice end even if all
-    records have an earlier ModifiedDate — preventing the same window from re-syncing."""
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
-    stream._current_slice = {
-        "cursor_field": "ModifiedDate",
-        "start": "2026-03-01T00:00:00Z",
-        "end": "2026-03-10T21:08:06Z",
-    }
-    current_state = {"ModifiedDate": "2026-03-01T00:00:00Z"}
-    # Record's ModifiedDate is older than slice end
-    latest_record = {"Gsid": "abc", "ModifiedDate": "2026-03-05T12:00:00Z"}
-    new_state = stream.get_updated_state(current_state, latest_record)
-    assert new_state == {"ModifiedDate": "2026-03-10T21:08:06Z"}
-
-
-def test_get_updated_state_uses_record_when_newer_than_slice_end(patch_base_class, mock_authenticator, mocker):
-    """If a record's cursor value is somehow newer than the slice end, the record value wins."""
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
-    stream._current_slice = {
-        "cursor_field": "ModifiedDate",
-        "start": "2026-03-01T00:00:00Z",
-        "end": "2026-03-05T00:00:00Z",
-    }
-    current_state = {"ModifiedDate": "2026-03-01T00:00:00Z"}
-    latest_record = {"Gsid": "abc", "ModifiedDate": "2026-03-09T00:04:30Z"}
-    new_state = stream.get_updated_state(current_state, latest_record)
-    assert new_state == {"ModifiedDate": "2026-03-09T00:04:30Z"}
-
-
-def test_get_updated_state_no_slice_still_advances_from_record(patch_base_class, mock_authenticator, mocker):
-    """Full-scan syncs (no active slice) still advance state from the latest record."""
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
-    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
-    stream._current_slice = None
-    current_state = {"ModifiedDate": "2026-03-01T00:00:00Z"}
-    latest_record = {"Gsid": "abc", "ModifiedDate": "2026-03-10T21:08:06Z"}
-    new_state = stream.get_updated_state(current_state, latest_record)
-    assert new_state == {"ModifiedDate": "2026-03-10T21:08:06Z"}
-
-
 def test_read_records_sets_and_clears_current_slice(patch_base_class, mock_authenticator, mocker):
     """_current_slice must be set during read_records and cleared afterwards,
-    so get_updated_state has access to the slice boundaries during the read."""
+    so the finally block has access to the slice boundaries to advance self._state."""
     from airbyte_cdk.models import SyncMode
 
     stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
@@ -349,3 +264,33 @@ def test_stream_slices_uses_catalog_cursor_when_no_modified_date(patch_base_clas
     assert first.get("cursor_field") == "LastModifiedDate"
     assert "start" in first and "end" in first
     assert first.get("cursor_format") == "date-time"
+
+
+def test_parse_response_advances_state_per_record(patch_base_class, mock_authenticator, mocker):
+    """parse_response must update self._state for each record so that CDK 0.90's
+    _observe_state() reads the correct cursor value for mid-stream and final STATE checkpoints."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(
+        stream,
+        "get_json_schema",
+        return_value={"properties": {"Gsid": {}, "ModifiedDate": {"type": ["null", "string"], "format": "date-time"}}},
+    )
+    stream._cursor_field_override = "ModifiedDate"
+
+    response = MagicMock()
+    response.json.return_value = {
+        "result": True,
+        "data": {
+            "records": [
+                {"Gsid": "a", "ModifiedDate": "2024-01-01T00:00:00Z"},
+                {"Gsid": "b", "ModifiedDate": "2024-03-01T00:00:00Z"},
+                {"Gsid": "c", "ModifiedDate": "2024-02-01T00:00:00Z"},
+            ]
+        },
+    }
+
+    records = list(stream.parse_response(response))
+
+    assert len(records) == 3
+    # State must reflect the highest cursor value seen, not just the last record
+    assert stream.state == {"ModifiedDate": "2024-03-01T00:00:00Z"}

--- a/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
@@ -160,6 +160,7 @@ def test_get_updated_state_advances_cursor(patch_base_class, mock_authenticator,
     latest_record = {"Gsid": "abc", "ModifiedDate": "2024-02-01T12:00:00Z"}
     new_state = stream.get_updated_state(current_state, latest_record)
     assert new_state == {"ModifiedDate": "2024-02-01T12:00:00Z"}
+    assert stream.state == {"ModifiedDate": "2024-02-01T12:00:00Z"}
 
 
 def test_get_updated_state_keeps_cursor_when_record_older(patch_base_class, mock_authenticator, mocker):
@@ -303,3 +304,48 @@ def test_read_records_sets_and_clears_current_slice(patch_base_class, mock_authe
 
     assert captured_slice_during_read["slice"] == test_slice
     assert stream._current_slice is None
+
+
+def test_stream_slices_uses_catalog_cursor_when_no_modified_date(patch_base_class, mock_authenticator, mocker):
+    """When stream has no ModifiedDate but catalog selects incremental with a different cursor (e.g. LastModifiedDate),
+    stream_slices must use the passed cursor_field for time-window slicing and state key."""
+    from airbyte_cdk.models import SyncMode
+
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    # Schema has LastModifiedDate (date-time) but NOT ModifiedDate
+    mocker.patch.object(
+        stream,
+        "get_json_schema",
+        return_value={
+            "properties": {
+                "Gsid": {},
+                "LastModifiedDate": {"type": ["null", "string"], "format": "date-time"},
+            }
+        },
+    )
+
+    # No cursor_field passed -> stream has no default cursor -> single full-scan slice
+    slices_no_cursor = list(
+        stream.stream_slices(
+            sync_mode=SyncMode.incremental,
+            cursor_field=None,
+            stream_state={"LastModifiedDate": "2024-01-01T00:00:00Z"},
+        )
+    )
+    assert len(slices_no_cursor) == 1
+    assert slices_no_cursor[0] == {}
+
+    # cursor_field passed from catalog (e.g. user chose LastModifiedDate) -> use it for slicing
+    slices_with_cursor = list(
+        stream.stream_slices(
+            sync_mode=SyncMode.incremental,
+            cursor_field=["LastModifiedDate"],
+            stream_state={"LastModifiedDate": "2024-01-01T00:00:00Z"},
+        )
+    )
+    # Should yield time-window slices with cursor_field LastModifiedDate
+    assert len(slices_with_cursor) >= 1
+    first = slices_with_cursor[0]
+    assert first.get("cursor_field") == "LastModifiedDate"
+    assert "start" in first and "end" in first
+    assert first.get("cursor_format") == "date-time"

--- a/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-gainsight-cs/unit_tests/test_streams.py
@@ -17,18 +17,24 @@ def patch_base_class(mocker):
     mocker.patch.object(GainsightCsStream, "url_base", f"{GAINSIGHT_DOMAIN_URL}/v1/")
     mocker.patch.object(GainsightCsStream, "__abstractmethods__", set())
     mocker.patch.object(GainsightCsObjectStream, "limit", 5)
-    mocker.patch.object(GainsightCsObjectStream, "offset", 0)
 
 
-def test_request_params(patch_base_class):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+@pytest.fixture
+def mock_authenticator():
+    auth = MagicMock()
+    auth.domain_url = GAINSIGHT_DOMAIN_URL
+    return auth
+
+
+def test_request_params(patch_base_class, mock_authenticator):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     inputs = {"stream_slice": None, "stream_state": None, "next_page_token": None}
     expected_params = {}
     assert stream.request_params(**inputs) == expected_params
 
 
-def test_next_page_token(patch_base_class):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+def test_next_page_token(patch_base_class, mock_authenticator):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     response = MagicMock()
     records = [{"test_id": "id1"}, {"test_id": "id2"}, {"test_id": "id3"}, {"test_id": "id4"}, {"test_id": "id5"}]
     response.json.return_value = {
@@ -41,8 +47,8 @@ def test_next_page_token(patch_base_class):
     assert stream.next_page_token(**inputs) == expected_token
 
 
-def test_next_page_token_end(patch_base_class):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+def test_next_page_token_end(patch_base_class, mock_authenticator):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     response = MagicMock()
     records = [{"test_id": "id1"}, {"test_id": "id2"}]
     response.json.return_value = {
@@ -55,8 +61,9 @@ def test_next_page_token_end(patch_base_class):
     assert stream.next_page_token(**inputs) == expected_token
 
 
-def test_parse_response(patch_base_class):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+def test_parse_response(patch_base_class, mock_authenticator, mocker):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"test_id": {}}})
     response = MagicMock()
     records = [{"test_id": "id1"}, {"test_id": "id2"}]
     expected_parsed_object = {
@@ -69,21 +76,21 @@ def test_parse_response(patch_base_class):
     assert next(stream.parse_response(**inputs)) == records[0]
 
 
-def test_request_headers(patch_base_class):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+def test_request_headers(patch_base_class, mock_authenticator):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     inputs = {"stream_slice": None, "stream_state": None, "next_page_token": None}
     expected_headers = {}
     assert stream.request_headers(**inputs) == expected_headers
 
 
-def test_http_method(patch_base_class):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+def test_http_method(patch_base_class, mock_authenticator):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     expected_method = "POST"
     assert stream.http_method == expected_method
 
 
-def test_path(patch_base_class):
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+def test_path(patch_base_class, mock_authenticator):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     inputs = {"stream_slice": None, "stream_state": None, "next_page_token": None}
     assert stream.path(**inputs) == f"data/objects/query/{GAINSIGHT_STREAM_NAME}"
 
@@ -97,15 +104,127 @@ def test_path(patch_base_class):
         (HTTPStatus.INTERNAL_SERVER_ERROR, True),
     ],
 )
-def test_should_retry(patch_base_class, http_status, should_retry):
+def test_should_retry(patch_base_class, mock_authenticator, http_status, should_retry):
     response_mock = MagicMock()
     response_mock.status_code = http_status
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     assert stream.should_retry(response_mock) == should_retry
 
 
-def test_backoff_time(patch_base_class):
+def test_backoff_time(patch_base_class, mock_authenticator):
     response_mock = MagicMock()
-    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, domain_url=GAINSIGHT_DOMAIN_URL)
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
     expected_backoff_time = None
     assert stream.backoff_time(response_mock) == expected_backoff_time
+
+
+def test_request_body_json_no_state_includes_no_where(patch_base_class, mock_authenticator, mocker):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_select_columns", return_value=["Gsid", "ModifiedDate"])
+    body = stream.request_body_json(stream_state=None, stream_slice=None, next_page_token=None)
+    assert "select" in body
+    assert body["select"] == ["Gsid", "ModifiedDate"]
+    assert "limit" in body
+    assert "offset" in body
+    assert "where" not in body
+
+
+def test_request_body_json_with_state_includes_where_gte(patch_base_class, mock_authenticator, mocker):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_select_columns", return_value=["Gsid", "ModifiedDate"])
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "ModifiedDate": {}}})
+    stream_state = {"ModifiedDate": "2024-01-15T10:00:00Z"}
+    body = stream.request_body_json(stream_state=stream_state, stream_slice=None, next_page_token=None)
+    assert body.get("where") == {
+        "conditions": [
+            {"name": "ModifiedDate", "alias": "A", "value": ["2024-01-15T10:00:00Z"], "operator": "GTE"}
+        ],
+        "expression": "A",
+    }
+
+
+def test_request_body_json_state_but_cursor_not_in_schema_no_where(patch_base_class, mock_authenticator, mocker):
+    """When cursor field is not in stream schema, we must not add where to avoid API error."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_select_columns", return_value=["Gsid", "Name"])
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "Name": {}}})
+    stream_state = {"ModifiedDate": "2024-01-15T10:00:00Z"}
+    body = stream.request_body_json(stream_state=stream_state, stream_slice=None, next_page_token=None)
+    assert "where" not in body
+
+
+def test_get_updated_state_advances_cursor(patch_base_class, mock_authenticator, mocker):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
+    current_state = {"ModifiedDate": "2024-01-01T00:00:00Z"}
+    latest_record = {"Gsid": "abc", "ModifiedDate": "2024-02-01T12:00:00Z"}
+    new_state = stream.get_updated_state(current_state, latest_record)
+    assert new_state == {"ModifiedDate": "2024-02-01T12:00:00Z"}
+
+
+def test_get_updated_state_keeps_cursor_when_record_older(patch_base_class, mock_authenticator, mocker):
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"ModifiedDate": {}}})
+    current_state = {"ModifiedDate": "2024-02-01T12:00:00Z"}
+    latest_record = {"Gsid": "abc", "ModifiedDate": "2024-01-01T00:00:00Z"}
+    new_state = stream.get_updated_state(current_state, latest_record)
+    assert new_state == {"ModifiedDate": "2024-02-01T12:00:00Z"}
+
+
+def test_get_updated_state_no_cursor_returns_current_state(patch_base_class, mock_authenticator, mocker):
+    """When stream has no cursor field (e.g. ModifiedDate not in schema), state is unchanged."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "Name": {}}})
+    current_state = {"other_key": "value"}
+    latest_record = {"Gsid": "abc", "Name": "foo"}
+    new_state = stream.get_updated_state(current_state, latest_record)
+    assert new_state == {"other_key": "value"}
+
+
+def test_as_airbyte_stream_with_modified_date(patch_base_class, mock_authenticator, mocker):
+    """Streams with ModifiedDate should advertise both sync modes, source-defined cursor, and ModifiedDate as default cursor field."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(
+        stream,
+        "get_json_schema",
+        return_value={"properties": {"Gsid": {}, "ModifiedDate": {"type": ["null", "string"], "format": "date-time"}}},
+    )
+    airbyte_stream = stream.as_airbyte_stream()
+
+    from airbyte_cdk.models import SyncMode as SM
+    assert SM.full_refresh in airbyte_stream.supported_sync_modes
+    assert SM.incremental in airbyte_stream.supported_sync_modes
+    assert airbyte_stream.source_defined_cursor is True
+    assert airbyte_stream.default_cursor_field == ["ModifiedDate"]
+
+
+def test_as_airbyte_stream_without_modified_date(patch_base_class, mock_authenticator, mocker):
+    """Streams without ModifiedDate should still advertise both sync modes, but with no source-defined cursor and no default cursor field,
+    so the UI defaults to Full Refresh | Append while still allowing Incremental | Append with a user-chosen cursor."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(
+        stream,
+        "get_json_schema",
+        return_value={"properties": {"Gsid": {}, "Date": {"type": ["null", "string"], "format": "date"}}},
+    )
+    airbyte_stream = stream.as_airbyte_stream()
+
+    from airbyte_cdk.models import SyncMode as SM
+    assert SM.full_refresh in airbyte_stream.supported_sync_modes
+    assert SM.incremental in airbyte_stream.supported_sync_modes
+    assert airbyte_stream.source_defined_cursor is False
+    assert not airbyte_stream.default_cursor_field
+
+
+def test_source_defined_cursor_true_when_modified_date_present(patch_base_class, mock_authenticator, mocker):
+    """source_defined_cursor should be True when ModifiedDate is in the stream schema."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "ModifiedDate": {}}})
+    assert stream.source_defined_cursor is True
+
+
+def test_source_defined_cursor_false_when_modified_date_absent(patch_base_class, mock_authenticator, mocker):
+    """source_defined_cursor should be False when ModifiedDate is not in the stream schema."""
+    stream = GainsightCsObjectStream(name=GAINSIGHT_STREAM_NAME, authenticator=mock_authenticator)
+    mocker.patch.object(stream, "get_json_schema", return_value={"properties": {"Gsid": {}, "Name": {}}})
+    assert stream.source_defined_cursor is False


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

This PR adds two improvements to the source-gainsight-cs connector:
1. Incremental sync support — All streams now advertise both full_refresh and incremental sync modes. Streams that have a `ModifiedDate` field in their schema automatically get a source-defined cursor pointing to ModifiedDate. Streams without `ModifiedDate` still expose incremental mode but leave cursor selection to the user.

2. Skip records on API error responses — Previously, a Gainsight API response with "result": false (e.g. error code P_5072) would cause the sync to crash or behave unpredictably. The connector now gracefully skips those records/pages and logs a warning rather than raising an exception, allowing the rest of the sync to continue.

## How
streams.py:
- Added cursor_field and source_defined_cursor properties that dynamically check if ModifiedDate is present in the stream's schema.
- Overrode as_airbyte_stream() to always expose both full_refresh and incremental sync modes, setting `source_defined_cursor=True` and `default_cursor_field=["ModifiedDate"]` only when `ModifiedDate` exists.
Added `get_updated_state()` to advance the cursor to the max of the current state and the latest record's cursor value.
- Updated `request_body_json()` to inject a GTE filter on the cursor field when state is present, skipping the filter (with a warning) if the cursor field is not in the schema to avoid API errors.
- Added `read_records()` override to capture the configured cursor field passed in by the Airbyte platform (e.g. a user-selected cursor like Date).
- Set `raise_on_http_errors = False` and updated parse_response() and next_page_token() to detect "result": false API responses and skip them gracefully with a warning log.
- Moved offset from a class-level variable to an instance-level variable to prevent state bleed between stream instances.
- source.py: Added a try/except around `GainsightCsAuthenticator` construction in `check_connection` to return a clean error instead of an unhandled exception on bad config.

Integration test fixtures:
- configured_catalog.json: Updated to use incremental sync mode with ModifiedDate as cursor.
sample_state.json / abnormal_state.json: Rewritten from placeholder format to valid Airbyte per-stream state message arrays.
- acceptance-test-config.yml: Removed the bypass_reason for incremental tests and wired up the future_state test using abnormal_state.json.
- Tests: Updated all unit tests in test_streams.py to use a proper mock_authenticator fixture, and added new tests covering incremental state advancement, where clause injection, as_airbyte_stream() behavior with and without `ModifiedDate`, and source_defined_cursor.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

- Start with streams.py — the core logic changes are in cursor_field, source_defined_cursor, as_airbyte_stream, get_updated_state, and request_body_json.
- Check parse_response and next_page_token for how the P_5072 / result: false error handling works.
- Review the integration test fixtures to confirm the state format follows the Airbyte per-stream state spec.
- Unit tests in test_streams.py cover the new incremental and error-skip logic end-to-end.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Gainsight CS connections configured with incremental sync mode will now correctly filter records using a GTE query on ModifiedDate, dramatically reducing the amount of data re-synced on each run. Connections that hit the P_5072 error (or any result: false response) will no longer fail mid-sync — they will skip the affected object and continue, logging a warning.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
