### PR TITLE
fix(source-pendo-python): update visitor's role field handling to accommodate mixed types

### DIFF
--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/source.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/source.py
@@ -70,7 +70,7 @@ class SourcePendoPython(AbstractSource):
 
         default_start_date = datetime.now() - timedelta(days=2 * 365)
         start_date = config.get("start_date", default_start_date.strftime("%Y-%m-%dT%H:%M:%S"))
-        day_page_size = config.get("day_page_size", 21)
+        day_page_size = config.get("day_page_size", 5)
 
         url_base = self._url_base(config)
 

--- a/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
+++ b/airbyte-integrations/connectors/source-pendo-python/source_pendo_python/streams.py
@@ -72,6 +72,9 @@ class PendoPythonStream(HttpStream, ABC):
                         fields[field] = {"type": ["null", "string", "number"]}
                     elif field == "sfpendolivedate": # sfpendogolivedate can be empty string or datetime string - tenant: ten_01k9qy066cfvgv3m14v0zprfd7
                         fields[field] = {"type": ["null", "string", "number"]}
+                    elif key == "agent" and field == "role":
+                        # Pendo metadata schema reports integer; API sometimes returns string slugs (e.g. "backoffice-user"). - tenant: ten_01kk264pkrf27teg2epq19qf1f
+                        fields[field] = {"type": ["null", "integer", "string"]}
                     else:
                         fields[field] = self.get_valid_field_info(field_type)
 
@@ -470,6 +473,7 @@ class FeatureEvents(PendoTimeSeriesAggregationStream):
         super().__init__(**kwargs)
         self.start_date = start_date
         self.day_page_size = day_page_size
+
 class GuideEvents(PendoTimeSeriesAggregationStream):
     name = "guide_events"
     source_name = "guideEvents"


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Widens the JSON schema in the connector. 

## How
<!--
* Describe how code changes achieve the solution.
-->

- treat `agent.role` as `["null", "integer", "string"]` so both numeric IDs and string slugs validate.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

- Fixes sync failures due to datatype mismatch issues. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
