### PR TITLE
feat(source-posthog): Extend PostHog events schema

### DIFF
--- a/airbyte-integrations/connectors/source-posthog/source_posthog/schemas/events.json
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/schemas/events.json
@@ -8,7 +8,83 @@
       "type": "string"
     },
     "properties": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "application": {
+          "type": ["string", "null"]
+        },
+        "status": {
+          "type": ["string", "null"]
+        },
+        "region": {
+          "type": ["string", "null"]
+        },
+        "tenantId": {
+          "type": ["integer", "string","null"]
+        },
+        "tenantName": {
+          "type": ["string", "null"]
+        },
+        "organizationName": {
+          "type": ["string", "null"]
+        },
+        "organizationId": {
+          "type": ["integer", "null"]
+        },
+        "accountName": {
+          "type": ["string", "null"]
+        },
+        "accountOwner": {
+          "type": ["string", "null"]
+        },
+        "email": {
+          "type": ["string", "null"]
+        },
+        "startedDate": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "completedDate": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "createdBy": {
+          "type": ["string", "null"]
+        },
+        "applicationUrl": {
+          "type": ["string", "null"]
+        },
+        "salesforce_org_id": {
+          "type": ["string", "null"]
+        },
+        "salesforce_org_name": {
+          "type": ["string", "null"]
+        },
+        "branch_id": {
+          "type": ["string", "null"]
+        },
+        "branch_name": {
+          "type": ["string", "null"]
+        },
+        "repository_id": {
+          "type": ["string", "null"]
+        },
+        "repository_name": {
+          "type": ["string", "null"]
+        },
+        "repository_type": {
+          "type": ["string", "null"]
+        },
+        "path": {
+          "type": ["string", "null"]
+        },
+        "title": {
+          "type": ["string", "null"]
+        },
+        "distinct_id": {
+          "type": ["string", "null"]
+        }
+      }
     },
     "event": {
       "type": "string"


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Extends the PostHog events stream schema to explicitly type high-value fields under properties, instead of leaving them as an untyped object that lands entirely in `_airbyte_additional_properties` at Parquet destinations.

## How
<!--
* Describe how code changes achieve the solution.
-->

Updates `source_posthog/schemas/events.json` to declare optional sub-properties on the properties object with appropriate JSON Schema types (string, integer, boolean, object, and date-time where applicable).

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

- `source_posthog/schemas/events.json`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

- Tier 1 business fields and Tier 2C session/client fields become queryable Parquet/warehouse columns

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
